### PR TITLE
feat(renovate-config): add immich rule

### DIFF
--- a/renovate-config/default.json5
+++ b/renovate-config/default.json5
@@ -33,6 +33,12 @@
   },
   packageRules: [
     {
+      groupName: 'immich docker containers',
+      groupSlug: 'immich',
+      matchDatasources: ['docker'],
+      matchPackageNames: ['ghcr.io/immich-app/**'],
+    },
+    {
       groupName: 'mastodon docker containers',
       groupSlug: 'mastodon',
       matchDatasources: ['docker'],


### PR DESCRIPTION
This pull request adds a new configuration rule to the Renovate bot settings to group updates for Immich Docker containers. This makes it easier to manage and review updates for these containers as a single group.

Renovate configuration improvements:

* Added a new `packageRules` entry to `renovate-config/default.json5` to group all Docker updates for packages matching `ghcr.io/immich-app/**` under the group name "immich docker containers".