### PR TITLE
refactor: update layout components to use LayoutProps and remove unused imports

### DIFF
--- a/apps/portfolio/app/layout.tsx
+++ b/apps/portfolio/app/layout.tsx
@@ -3,7 +3,6 @@ import { Analytics } from '@vercel/analytics/react'
 import clsx from 'clsx'
 import type { Metadata, Viewport } from 'next'
 import { Noto_Sans_JP, Raleway, Source_Sans_3 } from 'next/font/google'
-import type { ReactNode } from 'react'
 import SVGSymbols from './_components/svg-symbols'
 
 export const metadata: Metadata = {
@@ -41,11 +40,7 @@ const sourceSans3 = Source_Sans_3({
   weight: ['300', '600', '700']
 })
 
-export default function RootLayout({
-  children
-}: Readonly<{
-  children: ReactNode
-}>) {
+export default function RootLayout({ children }: LayoutProps<'/'>) {
   return (
     <html
       className={clsx(

--- a/apps/portfolio/app/page.tsx
+++ b/apps/portfolio/app/page.tsx
@@ -54,7 +54,7 @@ function About() {
   )
 }
 
-export default function HomePage() {
+export default function HomePage(_props: PageProps<'/'>) {
   return (
     <LayoutWrapper>
       <Section intro>

--- a/apps/portfolio/next.config.ts
+++ b/apps/portfolio/next.config.ts
@@ -5,7 +5,7 @@ const withMDX = createMDX()
 
 const nextConfig: NextConfig = {
   experimental: {
-    dynamicIO: true,
+    cacheComponents: true,
     mdxRs: {
       mdxType: 'gfm'
     },
@@ -56,7 +56,8 @@ const nextConfig: NextConfig = {
     }
   },
   pageExtensions: ['tsx', 'ts', 'mdx'],
-  reactStrictMode: true
+  reactStrictMode: true,
+  typedRoutes: true
 }
 
 export default withMDX(nextConfig)

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -36,7 +36,6 @@
   "scripts": {
     "build": "next build --turbopack",
     "dev": "next --turbopack",
-    "lint": "next lint -d .",
     "start": "next start",
     "typegen": "next typegen"
   },

--- a/apps/studio/app/[[...index]]/page.tsx
+++ b/apps/studio/app/[[...index]]/page.tsx
@@ -5,6 +5,6 @@ export const dynamic = 'force-static'
 
 export { metadata, viewport } from 'next-sanity/studio'
 
-export default function StudioPage() {
+export default function StudioPage(_props: PageProps<'/[[...index]]'>) {
   return <NextStudio config={sanityConfig} />
 }

--- a/apps/studio/app/layout.tsx
+++ b/apps/studio/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import type { ReactNode } from 'react'
 import styles from './layout.module.css'
 
 export const metadata: Metadata = {
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
   }
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: LayoutProps<'/'>) {
   return (
     <html lang="en">
       <body className={styles.body}>{children}</body>

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -30,9 +30,8 @@
     "url": "https://github.com/ykzts/ykzts.git"
   },
   "scripts": {
-    "build": "next build",
+    "build": "next build --turbopack",
     "dev": "next -p 10000 --turbopack",
-    "lint": "next lint -d .",
     "start": "next start -p 10000",
     "typegen": "next typegen"
   },


### PR DESCRIPTION
This pull request updates both the portfolio and studio Next.js apps to improve type safety, configuration, and developer experience. The most important changes include adopting typed route props for layout and page components, updating Next.js configuration options for better performance and type safety, and streamlining package scripts.

**Type Safety and Component Props**

* Updated all layout and page components in both apps to use typed route props (`LayoutProps` and `PageProps`), replacing generic `ReactNode` usage. This ensures better type safety and consistency across the codebase. [[1]](diffhunk://#diff-11b206963aac5528fbc7cf32ad442918a285159560540f296d651151cb2e0d8aL44-R43) [[2]](diffhunk://#diff-bc9d3ae9a9fe6dcfd699e6fa8bdcdcc13e0ca2b0085a656e26b271410ff842edL57-R57) [apps/studio/app/[[...index]]/page.tsxL8-R8](diffhunk://#diff-4e6039df993529f87b38575570ec30f80da0bb7de4e73866c9d65464d6d27a1cL8-R8), [[3]](diffhunk://#diff-178429570ef745e905100ae74e7c259537bc15c9ba4ddd0e2c795d100e8fd635L17-R16)

**Next.js Configuration Improvements**

* Changed experimental options in `apps/portfolio/next.config.ts` by replacing `dynamicIO` with `cacheComponents`, and enabled `typedRoutes` for improved route type safety. [[1]](diffhunk://#diff-dc2d4ab8e649768b232f7f2f71f911c773c5ec0299e5f986e11c33263ddadcbbL8-R8) [[2]](diffhunk://#diff-dc2d4ab8e649768b232f7f2f71f911c773c5ec0299e5f986e11c33263ddadcbbL59-R60)

**Package Script Streamlining**

* Removed the `lint` script from both `apps/portfolio/package.json` and `apps/studio/package.json` to simplify the scripts section. [[1]](diffhunk://#diff-a31f895b0076fdd38c163fd56c08d935b8b67862a96099e4628e3b1f695c9e93L39) [[2]](diffhunk://#diff-14a87cb8301b0736bd6722d3ad7b33f96f0da057b76a9aa6d98537b2a5ff69ceL33-L35)
* Updated `build` and `dev` scripts to use Next.js Turbopack for faster builds and development. [[1]](diffhunk://#diff-14a87cb8301b0736bd6722d3ad7b33f96f0da057b76a9aa6d98537b2a5ff69ceL33-L35) [[2]](diffhunk://#diff-a31f895b0076fdd38c163fd56c08d935b8b67862a96099e4628e3b1f695c9e93L39)

**Minor Cleanup**

* Removed unused `ReactNode` type imports from layout files for both apps. [[1]](diffhunk://#diff-11b206963aac5528fbc7cf32ad442918a285159560540f296d651151cb2e0d8aL6) [[2]](diffhunk://#diff-178429570ef745e905100ae74e7c259537bc15c9ba4ddd0e2c795d100e8fd635L2)