### PR TITLE
fix(studio): disable turbopack

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/ykzts/ykzts.git"
   },
   "scripts": {
-    "build": "next build",
+    "build": "next build --webpack",
     "dev": "next -p 10000",
     "start": "next start -p 10000",
     "test": "echo \"No tests configured for studio app\"",


### PR DESCRIPTION
This pull request makes a small update to the build script in the `apps/studio/package.json` file, specifying the use of webpack when running the Next.js build command. This change may be intended to ensure compatibility or to enable webpack-specific features in the build process.