### PR TITLE
fix(portfolio): fix `microfrontends.json`

### DIFF
--- a/apps/admin/app/admin/(authenticated)/layout.tsx
+++ b/apps/admin/app/admin/(authenticated)/layout.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { getCurrentUser } from '@/lib/auth'
-import { logout } from '../../login/actions'
+import { logout } from '../login/actions'
 
 function UserInfo({ user }: { user: User }) {
   return (

--- a/apps/portfolio/microfrontends.json
+++ b/apps/portfolio/microfrontends.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/microfrontends.json",
   "applications": {
-    "@ykzts/admin": {
+    "admin": {
       "development": {
         "fallback": "ykzts-admin.vercel.app",
         "local": 3001
       },
+      "packageName": "@ykzts/admin",
       "routing": [
         {
           "group": "admin",
@@ -13,11 +14,12 @@
         }
       ]
     },
-    "@ykzts/portfolio": {
+    "portfolio": {
       "development": {
-        "fallback": "ykzts.vercel.app",
+        "fallback": "ykzts.com",
         "local": 3000
-      }
+      },
+      "packageName": "@ykzts/portfolio"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the `apps/portfolio/microfrontends.json` configuration to simplify application naming and adjust fallback URLs. The main focus is on standardizing the application keys and improving the development fallback setup.

Configuration standardization:

* Changed application keys from `@ykzts/admin` and `@ykzts/portfolio` to `admin` and `portfolio` to remove the namespace prefix and simplify references. [[1]](diffhunk://#diff-7c7a0753407c6715d333f8a7daf082f571e67846f7ba855c7ce4fc9bf2abc864L4-R4) [[2]](diffhunk://#diff-7c7a0753407c6715d333f8a7daf082f571e67846f7ba855c7ce4fc9bf2abc864L16-R18)

Development environment improvements:

* Updated the `portfolio` application's development fallback URL from `ykzts.vercel.app` to `ykzts.com` for a more accurate local testing environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified public application key names for clarity.

* **Chores**
  * Added packageName entries for the public apps.
  * Updated the portfolio app's development fallback domain to ykzts.com.
  * Adjusted an internal import path to ensure correct module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->