### PR TITLE
feat(blog): improve blog migration and implement redirect functionality

### DIFF
--- a/apps/blog/proxy.ts
+++ b/apps/blog/proxy.ts
@@ -45,9 +45,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    // Only process non-standard blog paths that might be legacy redirects
-    // Excludes: API routes, _next, static files, canonical URLs, standard pages
-    '/blog/((?!api|_next|atom\\.xml|sitemap\\.xml|robots\\.txt|page\\/|tags\\/|\\d{4}\\/\\d{2}\\/\\d{2}\\/).+)'
-  ]
+  matcher: '/blog/:path*'
 }

--- a/scripts/blog-migration/lib/analyze-git-history.ts
+++ b/scripts/blog-migration/lib/analyze-git-history.ts
@@ -247,9 +247,16 @@ export async function generateVersionsFromHistory(filePath: string): Promise<
 
   // Version 1: Initial commit with date field as version_date
   const firstCommit = chronological[0]
-  const initialDate = firstCommit.frontmatter.date
-    ? new Date(firstCommit.frontmatter.date)
-    : firstCommit.date
+  const initialDate =
+    firstCommit.frontmatter.date ||
+    firstCommit.frontmatter.publishdate ||
+    firstCommit.frontmatter.publishDate
+      ? new Date(
+          firstCommit.frontmatter.date ||
+            firstCommit.frontmatter.publishdate ||
+            firstCommit.frontmatter.publishDate
+        )
+      : firstCommit.date
 
   versions.push({
     commitHash: firstCommit.hash,

--- a/scripts/blog-migration/lib/analyze-git-history.ts
+++ b/scripts/blog-migration/lib/analyze-git-history.ts
@@ -247,16 +247,11 @@ export async function generateVersionsFromHistory(filePath: string): Promise<
 
   // Version 1: Initial commit with date field as version_date
   const firstCommit = chronological[0]
-  const initialDate =
+  const rawDate =
     firstCommit.frontmatter.date ||
     firstCommit.frontmatter.publishdate ||
     firstCommit.frontmatter.publishDate
-      ? new Date(
-          firstCommit.frontmatter.date ||
-            firstCommit.frontmatter.publishdate ||
-            firstCommit.frontmatter.publishDate
-        )
-      : firstCommit.date
+  const initialDate = rawDate ? new Date(rawDate) : firstCommit.date
 
   versions.push({
     commitHash: firstCommit.hash,

--- a/scripts/blog-migration/lib/parse-mdx.ts
+++ b/scripts/blog-migration/lib/parse-mdx.ts
@@ -8,6 +8,8 @@ export interface Frontmatter {
     author?: string
     date?: string
   }
+  publishdate?: string // Legacy field for publish date
+  publishDate?: string // Alternative form of publishdate
   tags?: string[]
   title?: string
 }
@@ -86,6 +88,10 @@ function parseFrontmatter(frontmatterText: string): Frontmatter {
         frontmatter.date = value.trim()
       } else if (key === 'lastmod') {
         frontmatter.lastmod = value.trim()
+      } else if (key === 'publishdate') {
+        frontmatter.publishdate = value.trim()
+      } else if (key === 'publishDate') {
+        frontmatter.publishDate = value.trim()
       } else if (key === 'title') {
         // Remove quotes from YAML values (e.g., 'text' -> text, "text" -> text)
         let titleValue = value.trim()


### PR DESCRIPTION
## 概要

ブログ記事移行スクリプトの機能改善とリダイレクト機能を実装しました。

## 変更内容

### 1. 旧フィールドのサポート追加
- `publishdate`/`publishDate` フィールドに対応
- 旧記事の日付フィールドから正しい公開日を取得

### 2. スラッグ重複の動的解決
- タイトルからバージョン番号を自動抽出（例: `v3.0.0` → `v3`）
- 重複時に自動的にバージョンサフィックスを付与
- 例: `w3c-xmlhttprequest` (2013年版) と `w3c-xmlhttprequest-v3` (2020年版)

### 3. redirect_from実装
- `/blog/YYYY/MM/DD/slug` 形式のリダイレクトに対応
- データベースに旧URLを保存し、middlewareで301リダイレクト処理

### 4. proxy.ts修正
- matcherパターンを `/blog/:path*` に簡素化
- 不要な除外パターンを削除

### 5. 環境変数の簡素化  
- `MIGRATION_USER_ID` のみで実行可能に
- `MIGRATION_PROFILE_ID` は `profiles` テーブルから自動取得

## テスト結果

- ✅ 全51件のMDX記事が正常に移行
- ✅ 194バージョンが生成
- ✅ リダイレクト動作確認済み

## 関連Issue

#TBD (blog-legacy redirector issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified blog routing to use a straightforward path matcher for more reliable route handling.

* **New Features**
  * Support for publishDate and publishdate frontmatter fields.
  * Automatic duplicate-post slug resolution with redirect generation.

* **Improvements**
  * Better initial-date detection prioritizing publish date fields.
  * Stronger migration validation and clearer logging around profile resolution and slug handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->