### PR TITLE
chore(portfolio): prevent blog paths from being indexed in robots.txt

### DIFF
--- a/apps/portfolio/app/robots.ts
+++ b/apps/portfolio/app/robots.ts
@@ -5,6 +5,10 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
+        disallow: ['/blog', '/blog/'],
+        userAgent: '*'
+      },
+      {
         allow: '/',
         userAgent: '*'
       }


### PR DESCRIPTION
## 概要

ブログの検証期間中、検索エンジンにインデックスされないようにするため、robots.txtに新しいブログパスを追加します。

## 変更内容

-  と  のクローリングを禁止

## 理由

- 新しいブログシステムはまだ検証中です
- 検索エンジンのインデックスを防ぐ必要があります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine crawler rules to disallow blog section access and prevent indexing. Blog posts will no longer appear in search results, though the rest of the site remains searchable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->