### PR TITLE
chore(packages): modernize tsconfig presets and biome setup

### DIFF
--- a/packages/pagination-utils/biome.jsonc
+++ b/packages/pagination-utils/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": "//"
+}

--- a/packages/portable-text-utils/biome.jsonc
+++ b/packages/portable-text-utils/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": "//"
+}

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -70,4 +70,4 @@ npx supabase gen types typescript --linked > packages/supabase/src/database.type
 
 ## Internal Dependencies
 
-This package has no dependencies and can be used by any application in the monorepo.
+- `@ykzts/tsconfig` (dev dependency for TypeScript configuration)

--- a/packages/supabase/biome.jsonc
+++ b/packages/supabase/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": "//"
+}

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -3,7 +3,9 @@
   "description": "Supabase database type definitions for ykzts applications",
   "devDependencies": {
     "@types/node": "22.19.11",
-    "next": "16.1.6"
+    "@ykzts/tsconfig": "workspace:*",
+    "next": "16.1.6",
+    "typescript": "5.9.3"
   },
   "exports": {
     ".": {

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -19,8 +19,10 @@ Import the appropriate configuration preset in your project's `tsconfig.json`:
 ```
 
 Used by:
-- `@ykzts/portfolio`: Portfolio website
-- `@ykzts/studio`: Sanity CMS studio
+- `@ykzts/admin`
+- `@ykzts/blog`
+- `@ykzts/blog-legacy`
+- `@ykzts/portfolio`
 
 ### For Node.js Projects
 
@@ -31,7 +33,7 @@ Used by:
 ```
 
 Used by:
-- `@ykzts/schemas`: Schema definitions package
+- `@ykzts/supabase`
 
 ### For React Component Libraries
 
@@ -41,24 +43,29 @@ Used by:
 }
 ```
 
+Used by:
+- `@ykzts/pagination-utils`
+- `@ykzts/portable-text-utils`
+- `@ykzts/ui`
+
 ## Available Configurations
 
 ### `basic.json`
-- Target: ES2022
-- Module: Node16 with Node16 module resolution
+- Target: ES2023
+- Module: NodeNext with NodeNext module resolution
 - Strict mode enabled
-- Library support: DOM, DOM iterable, ES2022
-- Optimized for Node.js environments
+- Library support: DOM, DOM iterable, ES2023
+- Optimized for Node.js and modern ESM-compatible environments
 
 ### `react-library.json`
-- Target: ES2022
+- Target: ES2023
 - Module: ESNext with bundler module resolution
 - JSX: react-jsx (for component libraries)
 - Strict mode enabled
-- Library support: DOM, DOM iterable, ES2022
+- Library support: DOM, DOM iterable, ES2023
 
 ### `next.json`
-- Target: ES2022
+- Target: ES2023
 - Module: ESNext with bundler module resolution
 - JSX: preserve (for React components)
 - Includes incremental compilation and isolated modules
@@ -77,5 +84,5 @@ None - provides configuration only
 - Consistent TypeScript settings across the monorepo
 - Optimized configurations for different runtime environments
 - Strict type checking enabled by default
-- Modern ES2022 target for better performance
+- Modern ES2023 target for better performance
 - JSON schema validation support

--- a/packages/tsconfig/basic.json
+++ b/packages/tsconfig/basic.json
@@ -2,12 +2,12 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowJs": true,
-    "lib": ["dom", "dom.iterable", "es2022"],
-    "module": "node16",
-    "moduleResolution": "node16",
+    "lib": ["dom", "dom.iterable", "es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2023"
   }
 }

--- a/packages/tsconfig/next.json
+++ b/packages/tsconfig/next.json
@@ -7,13 +7,13 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": ["dom", "dom.iterable", "es2023"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2023"
   }
 }

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -4,12 +4,12 @@
     "allowJs": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": ["dom", "dom.iterable", "es2023"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2023"
   }
 }

--- a/packages/ui/biome.jsonc
+++ b/packages/ui/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": "//"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,9 +445,15 @@ importers:
       '@types/node':
         specifier: 22.19.11
         version: 22.19.11
+      '@ykzts/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   packages/tsconfig: {}
 


### PR DESCRIPTION
Modernizes shared package configuration under `packages/` to better match the current TypeScript/Next.js baseline and align repository-wide tooling setup.

## Changes

- **tsconfig presets**: Updated shared presets in `packages/tsconfig` from ES2022 to ES2023 and moved `basic.json` from `node16` to `nodenext`
- **tsconfig docs**: Refreshed `packages/tsconfig/README.md` to reflect current consumers in this monorepo and updated preset descriptions
- **biome configs**: Added missing `biome.jsonc` files to package workspaces (`pagination-utils`, `portable-text-utils`, `supabase`, `ui`) for consistency
- **supabase package alignment**: Added missing dev dependencies (`@ykzts/tsconfig`, `typescript`) and updated README dependency note
- **lockfile**: Updated `pnpm-lock.yaml` to reflect dependency changes

## Implementation

- `basic.json`: `target/lib` -> `es2023`, `module/moduleResolution` -> `nodenext`
- `next.json` / `react-library.json`: `target/lib` -> `es2023`
- All package-local Biome config files use the same shared extension format:
  - `{"$schema": "../../node_modules/@biomejs/biome/configuration_schema.json", "extends": "//"}`

## Validation

- `packages/*` tsconfig resolution check via `tsc --showConfig` (all pass)
- `pnpm --filter @ykzts/supabase exec tsc -p tsconfig.json --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development tooling configuration files across packages.
  * Updated TypeScript configurations to target ES2023 with improved module resolution.
  * Updated development dependencies including TypeScript 5.9.3.

* **Documentation**
  * Updated package documentation to reflect expanded usage across the monorepo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->