### PR TITLE
feat(admin): support profile metadata editing and fediverse verification

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -20,5 +20,5 @@ CRON_SECRET=your-cron-secret
 DRAFT_SECRET=your-draft-secret
 
 # Site Identity
-NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
 NEXT_PUBLIC_SITE_NAME=example.com
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -21,3 +21,4 @@ DRAFT_SECRET=your-draft-secret
 
 # Site Identity
 NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
+NEXT_PUBLIC_SITE_NAME=example.com

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -30,11 +30,31 @@ Visit http://localhost:3001/admin
 
 ## Environment Variables
 
-Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
+Copy `.env.example` to `.env.local` and set the following values:
 
 ```dotenv
+# Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+
+# Cache Revalidation
+# Comma-separated list of full revalidation endpoint URLs
+REVALIDATE_SECRET=your-secret-key
+REVALIDATE_URLS=http://localhost:3002/api/blog/revalidate,http://localhost:3000/api/revalidate
+
+# Cron Job Security
+CRON_SECRET=your-cron-secret
+
+# Draft Preview
+DRAFT_SECRET=your-draft-secret
+
+# Site Identity
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
+NEXT_PUBLIC_SITE_NAME=example.com
+
+# Optional AI provider key (depending on your AI Gateway/provider setup)
+OPENAI_API_KEY=
 ```
 
-AI features (slug generation, embeddings) use Vercel AI Gateway. Configure the OpenAI API key in your Vercel project settings.
+AI features (slug generation, embeddings) use Vercel AI Gateway.

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -50,8 +50,8 @@ CRON_SECRET=your-cron-secret
 DRAFT_SECRET=your-draft-secret
 
 # Site Identity
-NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
 NEXT_PUBLIC_SITE_NAME=example.com
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
 
 # Optional AI provider key (depending on your AI Gateway/provider setup)
 OPENAI_API_KEY=

--- a/apps/admin/app/(authenticated)/profile/edit/_components/profile-form.tsx
+++ b/apps/admin/app/(authenticated)/profile/edit/_components/profile-form.tsx
@@ -31,7 +31,9 @@ type ProfileFormProps = {
     about: Json | null
     avatar_url: string | null
     email: string | null
+    fediverse_creator: string | null
     name: string
+    occupation: string | null
     tagline: string | null
     timezone: string
   } | null
@@ -197,6 +199,18 @@ export default function ProfileForm({
       </div>
 
       <div>
+        <label className="mb-2 block font-medium" htmlFor="occupation">
+          職種・専門領域
+        </label>
+        <Input
+          defaultValue={initialData?.occupation ?? ''}
+          id="occupation"
+          name="occupation"
+          type="text"
+        />
+      </div>
+
+      <div>
         <label className="mb-2 block font-medium" htmlFor="email">
           メールアドレス
         </label>
@@ -206,6 +220,23 @@ export default function ProfileForm({
           name="email"
           type="email"
         />
+      </div>
+
+      <div>
+        <label className="mb-2 block font-medium" htmlFor="fediverse_creator">
+          fediverse:creator
+        </label>
+        <Input
+          defaultValue={initialData?.fediverse_creator ?? ''}
+          id="fediverse_creator"
+          name="fediverse_creator"
+          placeholder="@user@example.com"
+          type="text"
+        />
+        <p className="mt-2 text-muted-foreground text-sm">
+          記事やサイトのメタデータに出力する識別子です (例: @user@example.com /
+          user@example.com)
+        </p>
       </div>
 
       <div>

--- a/apps/admin/app/(authenticated)/profile/page.tsx
+++ b/apps/admin/app/(authenticated)/profile/page.tsx
@@ -62,12 +62,30 @@ async function ProfileContent() {
             </div>
           )}
 
+          {profile.occupation && (
+            <div>
+              <div className="mb-1 block font-medium text-sm">
+                職種・専門領域
+              </div>
+              <p>{profile.occupation}</p>
+            </div>
+          )}
+
           {profile.email && (
             <div>
               <div className="mb-1 block font-medium text-sm">
                 メールアドレス
               </div>
               <p>{profile.email}</p>
+            </div>
+          )}
+
+          {profile.fediverse_creator && (
+            <div>
+              <div className="mb-1 block font-medium text-sm">
+                fediverse:creator
+              </div>
+              <p>{profile.fediverse_creator}</p>
             </div>
           )}
 

--- a/apps/admin/lib/data.ts
+++ b/apps/admin/lib/data.ts
@@ -20,7 +20,7 @@ export async function getProfile() {
   const { data, error } = await supabase
     .from('profiles')
     .select(
-      'id, name, tagline, email, about, timezone, avatar_url, created_at, updated_at'
+      'id, name, occupation, tagline, email, fediverse_creator, about, timezone, avatar_url, created_at, updated_at'
     )
     .eq('user_id', user.id)
     .maybeSingle()

--- a/apps/blog/.env.example
+++ b/apps/blog/.env.example
@@ -13,5 +13,5 @@ CRON_SECRET=your-cron-secret
 DRAFT_SECRET=your-draft-secret
 
 # Site Identity
-NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
 NEXT_PUBLIC_SITE_NAME=example.com
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024

--- a/apps/blog/.env.example
+++ b/apps/blog/.env.example
@@ -14,3 +14,4 @@ DRAFT_SECRET=your-draft-secret
 
 # Site Identity
 NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
+NEXT_PUBLIC_SITE_NAME=example.com

--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
@@ -104,6 +104,7 @@ export async function generateMetadata({
   }
 
   const authorName = post.profile.name
+  const fediverseCreator = post.profile.fediverse_creator?.trim()
 
   return {
     authors: [{ name: authorName }],
@@ -115,6 +116,9 @@ export async function generateMetadata({
       title: post.title || DEFAULT_POST_TITLE,
       type: 'article',
       url: getDateBasedUrl(slug, post.published_at)
+    },
+    other: {
+      ...(fediverseCreator ? { 'fediverse:creator': fediverseCreator } : {})
     },
     title: post.title || DEFAULT_POST_TITLE,
     twitter: {

--- a/apps/blog/app/blog/draft/[slug]/page.tsx
+++ b/apps/blog/app/blog/draft/[slug]/page.tsx
@@ -59,9 +59,9 @@ export async function generateMetadata({
   const fediverseCreator = post.profile?.fediverse_creator?.trim()
 
   return {
-    other: {
-      ...(fediverseCreator ? { 'fediverse:creator': fediverseCreator } : {})
-    },
+    other: fediverseCreator
+      ? { 'fediverse:creator': fediverseCreator }
+      : undefined,
     title: post.title || DEFAULT_POST_TITLE
   }
 }

--- a/apps/blog/app/blog/draft/[slug]/page.tsx
+++ b/apps/blog/app/blog/draft/[slug]/page.tsx
@@ -56,7 +56,12 @@ export async function generateMetadata({
     }
   }
 
+  const fediverseCreator = post.profile?.fediverse_creator?.trim()
+
   return {
+    other: {
+      ...(fediverseCreator ? { 'fediverse:creator': fediverseCreator } : {})
+    },
     title: post.title || DEFAULT_POST_TITLE
   }
 }

--- a/apps/blog/app/blog/page.tsx
+++ b/apps/blog/app/blog/page.tsx
@@ -4,17 +4,33 @@ import BlogPagination from '@/components/blog-pagination'
 import Header from '@/components/header'
 import PostCard from '@/components/post-card'
 import { getPosts, getTotalPages } from '@/lib/supabase/posts'
+import { getPublisherProfile } from '@/lib/supabase/profiles'
 
-export const metadata: Metadata = {
-  description: 'ykztsの技術ブログ',
-  openGraph: {
-    description: 'ykztsの技術ブログ',
-    title: 'Blog',
-    type: 'website',
-    url: '/blog'
-  },
-  title: {
-    absolute: 'Blog'
+function buildDescription(profileName: string): string {
+  return `${profileName}の個人ブログ。さまざまなトピックについて発信しています。`
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  let description = buildDescription('このサイト')
+
+  try {
+    const profile = await getPublisherProfile()
+    description = buildDescription(profile.name)
+  } catch (error) {
+    console.error('Failed to load profile for blog metadata:', error)
+  }
+
+  return {
+    description,
+    openGraph: {
+      description,
+      title: 'Blog',
+      type: 'website',
+      url: '/blog'
+    },
+    title: {
+      absolute: 'Blog'
+    }
   }
 }
 

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -15,8 +15,8 @@ export async function generateMetadata(): Promise<Metadata> {
   try {
     const profile = await getPublisherProfile()
     fediverseCreator = profile.fediverse_creator?.trim() || null
-  } catch {
-    console.error('Failed to load profile for blog layout metadata')
+  } catch (error) {
+    console.error('Failed to load profile for blog layout metadata:', error)
   }
 
   return {

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -7,16 +7,28 @@ import { Inter, JetBrains_Mono, Noto_Sans_JP } from 'next/font/google'
 import DraftModeBannerClient from '@/components/draft-mode-banner-client'
 import Footer from '@/components/footer'
 import ThemeProvider from '@/components/theme-provider'
+import { getPublisherProfile } from '@/lib/supabase/profiles'
 
-export const metadata: Metadata = {
-  metadataBase: getSiteOrigin(),
-  other: {
-    'fediverse:creator': 'ykzts@ykzts.technology',
-    'Hatena::Bookmark': 'nocomment'
-  },
-  title: {
-    default: 'Blog',
-    template: '%s | Blog'
+export async function generateMetadata(): Promise<Metadata> {
+  let fediverseCreator: string | null = null
+
+  try {
+    const profile = await getPublisherProfile()
+    fediverseCreator = profile.fediverse_creator?.trim() || null
+  } catch {
+    console.error('Failed to load profile for blog layout metadata')
+  }
+
+  return {
+    metadataBase: getSiteOrigin(),
+    other: {
+      ...(fediverseCreator ? { 'fediverse:creator': fediverseCreator } : {}),
+      'Hatena::Bookmark': 'nocomment'
+    },
+    title: {
+      default: 'Blog',
+      template: '%s | Blog'
+    }
   }
 }
 

--- a/apps/blog/lib/supabase/posts.ts
+++ b/apps/blog/lib/supabase/posts.ts
@@ -16,7 +16,11 @@ function getClient(isDraft = false) {
 
 const POSTS_PER_PAGE = 10
 
-type Profile = { id: string; name: string } | null
+type Profile = {
+  fediverse_creator?: string | null
+  id: string
+  name: string
+} | null
 
 /**
  * Normalizes profile data from Supabase query results.
@@ -79,7 +83,8 @@ export async function getPosts(page = 1, isDraft = false) {
       published_at,
       profile:profiles!posts_profile_id_fkey(
         id,
-        name
+        name,
+        fediverse_creator
       ),
       current_version:post_versions!posts_current_version_id_fkey(
         content,
@@ -141,7 +146,8 @@ export async function getPostBySlug(slug: string, isDraft = false) {
       published_at,
       profile:profiles!posts_profile_id_fkey(
         id,
-        name
+        name,
+        fediverse_creator
       ),
       current_version:post_versions!posts_current_version_id_fkey(
         content,
@@ -212,7 +218,8 @@ export async function getPostsByTag(tag: string, page = 1, isDraft = false) {
       published_at,
       profile:profiles!posts_profile_id_fkey(
         id,
-        name
+        name,
+        fediverse_creator
       ),
       current_version:post_versions!posts_current_version_id_fkey(
         content,
@@ -681,7 +688,8 @@ export async function getPostsByYear(year: number, isDraft = false) {
       published_at,
       profile:profiles!posts_profile_id_fkey(
         id,
-        name
+        name,
+        fediverse_creator
       ),
       current_version:post_versions!posts_current_version_id_fkey(
         content,

--- a/apps/blog/lib/supabase/profiles.ts
+++ b/apps/blog/lib/supabase/profiles.ts
@@ -14,7 +14,7 @@ export async function getPublisherProfile() {
 
   const { data: profileData, error: profileError } = await supabase
     .from('profiles')
-    .select('id, name, avatar_url, tagline')
+    .select('id, name, avatar_url, tagline, email, fediverse_creator')
     .maybeSingle()
 
   if (profileError) {

--- a/apps/blog/lib/supabase/profiles.ts
+++ b/apps/blog/lib/supabase/profiles.ts
@@ -14,7 +14,7 @@ export async function getPublisherProfile() {
 
   const { data: profileData, error: profileError } = await supabase
     .from('profiles')
-    .select('id, name, avatar_url, tagline, email, fediverse_creator')
+    .select('id, name, avatar_url, tagline, fediverse_creator')
     .maybeSingle()
 
   if (profileError) {

--- a/apps/portfolio/.env.example
+++ b/apps/portfolio/.env.example
@@ -8,5 +8,13 @@ REVALIDATE_SECRET=your-secret-key
 NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
 NEXT_PUBLIC_SITE_NAME=example.com
 
+# Optional: portfolio top page description for SEO
+NEXT_PUBLIC_PORTFOLIO_DESCRIPTION=
+
 # Mail Sender (Resend)
+RESEND_API_KEY=your-resend-api-key
 MAIL_FROM_ADDRESS=no-reply@example.com
+
+# Cloudflare Turnstile
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key
+TURNSTILE_SECRET_KEY=your-turnstile-secret-key

--- a/apps/portfolio/.env.example
+++ b/apps/portfolio/.env.example
@@ -12,8 +12,8 @@ NEXT_PUBLIC_SITE_NAME=example.com
 NEXT_PUBLIC_PORTFOLIO_DESCRIPTION=
 
 # Mail Sender (Resend)
-RESEND_API_KEY=your-resend-api-key
 MAIL_FROM_ADDRESS=no-reply@example.com
+RESEND_API_KEY=your-resend-api-key
 
 # Cloudflare Turnstile
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key

--- a/apps/portfolio/README.md
+++ b/apps/portfolio/README.md
@@ -108,10 +108,6 @@ See `.env.example` for a complete list of required environment variables.
 - `@tailwindcss/typography`: Typography plugin for Tailwind CSS
 - `postcss`: CSS transformation tool
 - `autoprefixer`: PostCSS plugin for vendor prefixes
-- `@lhci/cli`: Lighthouse CI for automated performance auditing
-- `@playwright/test`: End-to-end and accessibility testing
-- `@axe-core/playwright`: Accessibility testing integration
-- `vitest`: Fast unit testing framework
 
 ## Architecture
 

--- a/apps/portfolio/README.md
+++ b/apps/portfolio/README.md
@@ -48,17 +48,27 @@ pnpm lighthouse # Run Lighthouse CI performance audit
 The application requires the following environment variables:
 
 ```bash
-# Resend API Configuration
-RESEND_API_KEY=your_resend_api_key_here
-CONTACT_EMAIL="John Doe <test@example.com>"
-
-# Cloudflare Turnstile Configuration
-NEXT_PUBLIC_TURNSTILE_SITE_KEY=your_turnstile_site_key_here
-TURNSTILE_SECRET_KEY=your_turnstile_secret_key_here
-
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
+
+# Cache Revalidation
+REVALIDATE_SECRET=your-secret-key
+
+# Site Identity
+NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3024
+NEXT_PUBLIC_SITE_NAME=example.com
+
+# Optional: portfolio top page description for SEO
+NEXT_PUBLIC_PORTFOLIO_DESCRIPTION=
+
+# Mail Sender (Resend)
+RESEND_API_KEY=your-resend-api-key
+MAIL_FROM_ADDRESS=no-reply@example.com
+
+# Cloudflare Turnstile
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key
+TURNSTILE_SECRET_KEY=your-turnstile-secret-key
 ```
 
 See `.env.example` for a complete list of required environment variables.

--- a/apps/portfolio/app/_actions/contact.ts
+++ b/apps/portfolio/app/_actions/contact.ts
@@ -81,7 +81,7 @@ export async function submitContactForm(
       }
 
       if (!contactEmail) {
-        console.error('CONTACT_EMAIL is not configured.')
+        console.error('contactEmail in profile is not configured.')
       }
 
       return {

--- a/apps/portfolio/app/layout.tsx
+++ b/apps/portfolio/app/layout.tsx
@@ -1,22 +1,36 @@
 import './globals.css'
 import { Analytics } from '@vercel/analytics/react'
-import { getSiteOrigin } from '@ykzts/site-config'
+import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
 import { Toaster } from '@ykzts/ui/components/sonner'
 import type { Metadata, Viewport } from 'next'
 import { Inter, JetBrains_Mono, Noto_Sans_JP } from 'next/font/google'
 import { twMerge } from 'tailwind-merge'
+import { getProfile } from '@/lib/supabase'
 import SVGSymbols from './_components/svg-symbols'
 import ThemeProvider from './_components/theme-provider'
 
-export const metadata: Metadata = {
-  metadataBase: getSiteOrigin(),
-  other: {
-    'fediverse:creator': 'ykzts@ykzts.technology',
-    'Hatena::Bookmark': 'nocomment'
-  },
-  title: {
-    default: process.env.NEXT_PUBLIC_SITE_NAME ?? 'example.com',
-    template: `%s | ${process.env.NEXT_PUBLIC_SITE_NAME ?? 'example.com'}`
+const siteName = getSiteName()
+
+export async function generateMetadata(): Promise<Metadata> {
+  let fediverseCreator: string | null = null
+
+  try {
+    const profile = await getProfile()
+    fediverseCreator = profile.fediverse_creator?.trim() || null
+  } catch {
+    console.error('Failed to load profile for portfolio layout metadata')
+  }
+
+  return {
+    metadataBase: getSiteOrigin(),
+    other: {
+      ...(fediverseCreator ? { 'fediverse:creator': fediverseCreator } : {}),
+      'Hatena::Bookmark': 'nocomment'
+    },
+    title: {
+      default: siteName,
+      template: `%s | ${siteName}`
+    }
   }
 }
 

--- a/apps/portfolio/app/llms-full.txt/route.ts
+++ b/apps/portfolio/app/llms-full.txt/route.ts
@@ -5,9 +5,7 @@ import { getPostsForLlmsFull, getWorks } from '@/lib/supabase'
 export async function GET() {
   const [works, posts] = await Promise.all([getWorks(), getPostsForLlmsFull()])
 
-  const sections: string[] = getLlmsHeaderLines()
-
-  sections.push('', '## Works', '')
+  const sections: string[] = [...getLlmsHeaderLines(), '', '## Works', '']
 
   for (const work of works) {
     const url = buildWorkUrl(work.slug)

--- a/apps/portfolio/app/llms-full.txt/route.ts
+++ b/apps/portfolio/app/llms-full.txt/route.ts
@@ -1,26 +1,16 @@
 import { portableTextToMarkdown } from '@ykzts/portable-text-utils'
-import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
-import { buildPostUrl } from '@/lib/llms'
+import { buildPostUrl, buildWorkUrl, getLlmsHeaderLines } from '@/lib/llms'
 import { getPostsForLlmsFull, getWorks } from '@/lib/supabase'
 
 export async function GET() {
   const [works, posts] = await Promise.all([getWorks(), getPostsForLlmsFull()])
 
-  const siteOrigin = getSiteOrigin()
-  const siteName = getSiteName()
-
-  const sections: string[] = [
-    `# ${siteName}`,
-    '',
-    '> ポートフォリオと技術ブログ。JavaScriptやRubyといったプログラミング言語を用いたウェブアプリケーションの開発を得意とするソフトウェア開発者 山岸和利のサイトです。',
-    '',
-    'このサイトは、ポートフォリオと技術ブログを統合したサービスです。'
-  ]
+  const sections: string[] = getLlmsHeaderLines()
 
   sections.push('', '## Works', '')
 
   for (const work of works) {
-    const url = new URL(`/#${work.slug}`, siteOrigin).toString()
+    const url = buildWorkUrl(work.slug)
     sections.push(`### [${work.title}](${url})`, '')
     const content = portableTextToMarkdown(work.content)
     if (content) {

--- a/apps/portfolio/app/llms.txt/route.ts
+++ b/apps/portfolio/app/llms.txt/route.ts
@@ -1,27 +1,14 @@
 import { extractFirstParagraph } from '@ykzts/portable-text-utils'
-import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
-import { buildPostUrl } from '@/lib/llms'
+import { buildPostUrl, buildWorkUrl, getLlmsHeaderLines } from '@/lib/llms'
 import { getPostsForLlms, getWorks } from '@/lib/supabase'
 
 export async function GET() {
   const [works, posts] = await Promise.all([getWorks(), getPostsForLlms()])
 
-  const siteOrigin = getSiteOrigin()
-  const siteName = getSiteName()
-
-  const lines: string[] = [
-    `# ${siteName}`,
-    '',
-    '> ポートフォリオと技術ブログ。JavaScriptやRubyといったプログラミング言語を用いたウェブアプリケーションの開発を得意とするソフトウェア開発者 山岸和利のサイトです。',
-    '',
-    'このサイトは、ポートフォリオと技術ブログを統合したサービスです。',
-    '',
-    '## Works',
-    ''
-  ]
+  const lines: string[] = [...getLlmsHeaderLines(), '', '## Works', '']
 
   for (const work of works) {
-    const url = new URL(`/#${work.slug}`, siteOrigin).toString()
+    const url = buildWorkUrl(work.slug)
     const description = extractFirstParagraph(work.content)
     const suffix = description ? `: ${description}` : ''
     lines.push(`- [${work.title}](${url})${suffix}`)

--- a/apps/portfolio/app/page.tsx
+++ b/apps/portfolio/app/page.tsx
@@ -1,5 +1,7 @@
+import { getPortfolioDescription, getSiteName } from '@ykzts/site-config'
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { getProfile } from '@/lib/supabase'
 import About from './_components/about'
 import Contact from './_components/contact'
 import Footer from './_components/footer'
@@ -7,27 +9,41 @@ import Hero from './_components/hero'
 import Navigation from './_components/navigation'
 import Works from './_components/works'
 
-const description = [
-  'JavaScriptやRubyといったプログラミング言語を用いたウェブアプリケーションの開発を得意とするソフトウェア開発者 山岸和利のポートフォリオです。',
-  '山岸和利による過去の実績や作品の掲載、各種ソーシャルネットワーキングサービスのアカウントへのリンクなどの連絡先への参照があります。'
-].join('')
+const siteName = getSiteName()
 
-export const metadata: Metadata = {
-  alternates: {
-    canonical: '/'
-  },
-  description,
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  const description = getPortfolioDescription()
+  const fallbackTitle = `${siteName} - ポートフォリオ`
+  let absoluteTitle = fallbackTitle
+
+  try {
+    const profile = await getProfile()
+    const occupation = profile.occupation?.trim()
+    const titleSuffix = [occupation, profile.name].filter(Boolean).join(' ')
+    absoluteTitle = titleSuffix
+      ? `${siteName} - ${titleSuffix}のポートフォリオ`
+      : fallbackTitle
+  } catch (error) {
+    console.error('Failed to load profile for portfolio metadata:', error)
+  }
+
+  return {
+    alternates: {
+      canonical: '/'
+    },
     description,
-    title: process.env.NEXT_PUBLIC_SITE_NAME ?? 'example.com',
-    type: 'website',
-    url: '/'
-  },
-  title: {
-    absolute: `${process.env.NEXT_PUBLIC_SITE_NAME ?? 'example.com'} - ソフトウェア開発者 山岸和利のポートフォリオ`
-  },
-  twitter: {
-    card: 'summary_large_image'
+    openGraph: {
+      description,
+      title: siteName,
+      type: 'website',
+      url: '/'
+    },
+    title: {
+      absolute: absoluteTitle
+    },
+    twitter: {
+      card: 'summary_large_image'
+    }
   }
 }
 
@@ -37,7 +53,7 @@ export default function HomePage(_props: PageProps<'/'>) {
       <header className="sticky top-0 z-10 border-border border-b bg-background/90 px-6 backdrop-blur-sm md:px-12 lg:px-24">
         <div className="mx-auto flex h-14 max-w-4xl items-center justify-between">
           <Link className="font-semibold text-foreground text-lg" href="/">
-            {process.env.NEXT_PUBLIC_SITE_NAME ?? 'example.com'}
+            {siteName}
           </Link>
           <Navigation />
         </div>

--- a/apps/portfolio/app/robots.ts
+++ b/apps/portfolio/app/robots.ts
@@ -1,13 +1,11 @@
+import { getSiteOrigin } from '@ykzts/site-config'
 import type { MetadataRoute } from 'next'
-import { metadata } from '@/app/layout'
 
 export default function robots(): MetadataRoute.Robots {
-  const { metadataBase: baseUrl } = metadata
-  const sitemap = baseUrl
-    ? ['/sitemap.xml', '/blog/sitemap.xml'].map((path) =>
-        new URL(path, baseUrl).toString()
-      )
-    : []
+  const siteOrigin = getSiteOrigin()
+  const sitemap = ['/sitemap.xml', '/blog/sitemap.xml'].map((path) =>
+    new URL(path, siteOrigin).toString()
+  )
 
   return {
     rules: [

--- a/apps/portfolio/app/sitemap.ts
+++ b/apps/portfolio/app/sitemap.ts
@@ -1,21 +1,19 @@
+import { getSiteOrigin } from '@ykzts/site-config'
 import type { MetadataRoute } from 'next'
-import { metadata } from '@/app/layout'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  if (!metadata.metadataBase) {
-    return []
-  }
+  const siteOrigin = getSiteOrigin()
 
   return [
     {
       changeFrequency: 'monthly',
       priority: 0.8,
-      url: new URL('/', metadata.metadataBase).toString()
+      url: new URL('/', siteOrigin).toString()
     },
     {
       changeFrequency: 'yearly',
       priority: 0.1,
-      url: new URL('/privacy', metadata.metadataBase).toString()
+      url: new URL('/privacy', siteOrigin).toString()
     }
   ]
 }

--- a/apps/portfolio/docs/privacy.mdx
+++ b/apps/portfolio/docs/privacy.mdx
@@ -51,9 +51,9 @@ Vercel Web Analyticsは、**Cookieを使用せず**、IPアドレスなどの個
 
 本ポリシーに関するお問い合わせ、または個人情報の取り扱いに関するご質問は、以下にご連絡ください。
 
-**[ykzts@desire.sh](mailto:ykzts@desire.sh)**
+**[お問い合わせフォーム](/#contact)**
 
 ---
 
-公開日：<time dateTime="2025-09-28T00:00:00+09:00">2025年9月28日</time><br />
-最終更新日：<time dateTime="2025-09-28T00:00:00+09:00">2025年9月28日</time>
+公開日：<time dateTime="2025-09-28">2025年9月28日</time><br />
+最終更新日：<time dateTime="2026-02-21">2026年2月21日</time>

--- a/apps/portfolio/lib/llms.ts
+++ b/apps/portfolio/lib/llms.ts
@@ -1,4 +1,26 @@
-import { getSiteOrigin } from '@ykzts/site-config'
+import {
+  getPortfolioDescription,
+  getSiteName,
+  getSiteOrigin
+} from '@ykzts/site-config'
+
+export function getLlmsHeaderLines(): string[] {
+  const siteName = getSiteName()
+  const portfolioDescription = getPortfolioDescription()
+
+  return [
+    `# ${siteName}`,
+    '',
+    `> ${portfolioDescription}`,
+    '',
+    'このサイトは、ポートフォリオと技術ブログを統合したサービスです。'
+  ]
+}
+
+export function buildWorkUrl(slug: string): string {
+  const siteOrigin = getSiteOrigin()
+  return new URL(`/#${slug}`, siteOrigin).toString()
+}
 
 export function buildPostUrl(slug: string, publishedAt: string): string {
   const siteOrigin = getSiteOrigin()

--- a/apps/portfolio/lib/supabase.ts
+++ b/apps/portfolio/lib/supabase.ts
@@ -30,9 +30,11 @@ export async function getProfile() {
       `
         id,
         name,
+        occupation,
         tagline,
         about,
         email,
+        fediverse_creator,
         avatar_url,
         social_links(url, service),
         technologies(name)

--- a/packages/site-config/package.json
+++ b/packages/site-config/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "22.19.11",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "5.9.3",
     "vitest": "4.0.18"

--- a/packages/site-config/src/index.test.ts
+++ b/packages/site-config/src/index.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getSiteHost, getSiteName, getSiteOrigin } from './index'
+import {
+  getPortfolioDescription,
+  getSiteHost,
+  getSiteName,
+  getSiteOrigin
+} from './index'
 
 afterEach(() => {
   vi.unstubAllEnvs()
@@ -43,5 +48,17 @@ describe('getSiteName', () => {
   it('returns the name from NEXT_PUBLIC_SITE_NAME when set', () => {
     vi.stubEnv('NEXT_PUBLIC_SITE_NAME', 'ykzts.com')
     expect(getSiteName()).toBe('ykzts.com')
+  })
+})
+
+describe('getPortfolioDescription', () => {
+  it('returns the fallback description when env is not set', () => {
+    vi.stubEnv('NEXT_PUBLIC_PORTFOLIO_DESCRIPTION', undefined)
+    expect(getPortfolioDescription()).toContain('ポートフォリオ')
+  })
+
+  it('returns the description from NEXT_PUBLIC_PORTFOLIO_DESCRIPTION when set', () => {
+    vi.stubEnv('NEXT_PUBLIC_PORTFOLIO_DESCRIPTION', 'SEO向けの説明文です。')
+    expect(getPortfolioDescription()).toBe('SEO向けの説明文です。')
   })
 })

--- a/packages/site-config/src/index.ts
+++ b/packages/site-config/src/index.ts
@@ -1,5 +1,7 @@
 const FALLBACK_ORIGIN = 'https://example.com'
 const FALLBACK_NAME = 'example.com'
+const FALLBACK_PORTFOLIO_DESCRIPTION =
+  'ウェブアプリケーション開発の実績や制作物を掲載したポートフォリオです。過去の実績、作品、各種ソーシャルネットワーキングサービスへのリンクなどの連絡先情報をまとめています。'
 
 /**
  * Returns the site origin as a URL object.
@@ -28,4 +30,15 @@ export function getSiteHost(): string {
  */
 export function getSiteName(): string {
   return process.env.NEXT_PUBLIC_SITE_NAME ?? FALLBACK_NAME
+}
+
+/**
+ * Returns the portfolio description text for metadata.
+ * Reads `NEXT_PUBLIC_PORTFOLIO_DESCRIPTION` and falls back to a default copy.
+ */
+export function getPortfolioDescription(): string {
+  return (
+    process.env.NEXT_PUBLIC_PORTFOLIO_DESCRIPTION ??
+    FALLBACK_PORTFOLIO_DESCRIPTION
+  )
 }

--- a/packages/supabase/src/database.types.ts
+++ b/packages/supabase/src/database.types.ts
@@ -166,8 +166,10 @@ export type Database = {
           avatar_url: string | null
           created_at: string
           email: string | null
+          fediverse_creator: string | null
           id: string
           name: string
+          occupation: string | null
           tagline: string | null
           timezone: string
           updated_at: string
@@ -178,8 +180,10 @@ export type Database = {
           avatar_url?: string | null
           created_at?: string
           email?: string | null
+          fediverse_creator?: string | null
           id?: string
           name: string
+          occupation?: string | null
           tagline?: string | null
           timezone?: string
           updated_at?: string
@@ -190,8 +194,10 @@ export type Database = {
           avatar_url?: string | null
           created_at?: string
           email?: string | null
+          fediverse_creator?: string | null
           id?: string
           name?: string
+          occupation?: string | null
           tagline?: string | null
           timezone?: string
           updated_at?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 2.95.3
       '@vercel/microfrontends':
         specifier: 2.3.0
-        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
       '@ykzts/pagination-utils':
         specifier: workspace:*
         version: link:../../packages/pagination-utils
@@ -146,10 +146,10 @@ importers:
         version: 2.95.3
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/microfrontends':
         specifier: 2.3.0
-        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
       '@ykzts/pagination-utils':
         specifier: workspace:*
         version: link:../../packages/pagination-utils
@@ -258,7 +258,7 @@ importers:
     dependencies:
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@ykzts/site-config':
         specifier: workspace:*
         version: link:../../packages/site-config
@@ -313,10 +313,10 @@ importers:
         version: 2.95.3
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/microfrontends':
         specifier: 2.3.0
-        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
       '@ykzts/portable-text-utils':
         specifier: workspace:*
         version: link:../../packages/portable-text-utils
@@ -475,6 +475,9 @@ importers:
 
   packages/site-config:
     devDependencies:
+      '@types/node':
+        specifier: 22.19.11
+        version: 22.19.11
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -483,7 +486,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2)
 
   packages/supabase:
     devDependencies:
@@ -9682,13 +9685,13 @@ snapshots:
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -9733,7 +9736,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
 
   '@types/md5@2.3.6': {}
 
@@ -9756,6 +9759,7 @@ snapshots:
   '@types/node@24.10.13':
     dependencies:
       undici-types: 7.16.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -9775,7 +9779,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
 
   '@types/semver@7.7.1': {}
 
@@ -9787,21 +9791,21 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
     optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  '@vercel/microfrontends@2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
+  '@vercel/microfrontends@2.3.0(@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@next/env': 16.0.10
       '@types/md5': 2.3.6
@@ -9816,7 +9820,7 @@ snapshots:
       path-to-regexp: 6.3.0
       semver: 7.7.4
     optionalDependencies:
-      '@vercel/analytics': 1.6.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@vercel/analytics': 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10416,7 +10420,7 @@ snapshots:
 
   chrome-launcher@0.13.4:
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
       escape-string-regexp: 1.0.5
       is-wsl: 2.2.0
       lighthouse-logger: 1.2.0
@@ -10427,7 +10431,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -13094,7 +13098,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
       long: 5.3.2
 
   protocols@2.0.2: {}
@@ -13865,7 +13869,7 @@ snapshots:
 
   speedline-core@1.4.3:
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.11
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
 
@@ -14257,7 +14261,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.16.0:
+    optional: true
 
   undici@7.22.0: {}
 

--- a/supabase/migrations/20260221000000_add_occupation_to_profiles.sql
+++ b/supabase/migrations/20260221000000_add_occupation_to_profiles.sql
@@ -1,0 +1,7 @@
+-- Migration: Add occupation and fediverse creator fields to profiles for metadata generation
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS occupation TEXT,
+  ADD COLUMN IF NOT EXISTS fediverse_creator TEXT;
+
+COMMENT ON COLUMN profiles.occupation IS 'Professional domain/occupation label for profile';
+COMMENT ON COLUMN profiles.fediverse_creator IS 'Fediverse creator handle used for metadata (e.g. user@example.com)';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -81,6 +81,8 @@ INSERT INTO profiles (
   tagline,
   about,
   email,
+  occupation,
+  fediverse_creator,
   created_at,
   updated_at
 ) VALUES (
@@ -135,6 +137,8 @@ INSERT INTO profiles (
     }
   ]'::jsonb,
   NULL,
+  'Software Developer',
+  'testuser@example.com',
   NOW(),
   NOW()
 )
@@ -144,6 +148,8 @@ ON CONFLICT (id) DO UPDATE SET
   tagline = EXCLUDED.tagline,
   about = EXCLUDED.about,
   email = EXCLUDED.email,
+  occupation = EXCLUDED.occupation,
+  fediverse_creator = EXCLUDED.fediverse_creator,
   updated_at = NOW();
 
 -- Insert social links for test user


### PR DESCRIPTION
## Summary
- add admin UI and save logic for `occupation` and `fediverse_creator`
- support `@user@domain` and `user@domain` input for fediverse creator with WebFinger validation
- source metadata fields from profiles in blog/portfolio and remove hardcoded personal values
- consolidate profile metadata migrations and update seed data
- align app-level `.env.example` and related README environment variable docs

## Verification
- checked TypeScript/diagnostics for updated admin profile files
- validated final diffs and branch push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added occupation and Fediverse creator fields to user profiles with optional verification; these appear on profile pages and can be included in post metadata and feeds.
  * Metadata generation made dynamic across blog, portfolio, and feeds for improved SEO and publisher attribution.
  * New portfolio description helper and LLMS header/URL helpers for better content/export headers.

* **Documentation**
  * Updated environment variable guidance and README sections; added new site, revalidation, mail, and Turnstile config entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->