### PR TITLE
refactor: use @tailwindcss/typography custom theme properly

### DIFF
--- a/apps/blog/components/portable-text.tsx
+++ b/apps/blog/components/portable-text.tsx
@@ -4,14 +4,6 @@ import {
   type PortableTextMarkComponentProps,
   type PortableTextReactComponents
 } from '@portabletext/react'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from '@ykzts/ui/components/table'
 import Image from 'next/image'
 import { type ComponentProps, Suspense } from 'react'
 import Link from '@/components/link'
@@ -185,28 +177,26 @@ const portableTextComponents = {
       const headerRow = hasHeader ? value.rows[0] : null
       const bodyRows = hasHeader ? value.rows.slice(1) : value.rows
       return (
-        <div className="not-prose my-6">
-          <Table>
-            {headerRow && (
-              <TableHeader>
-                <TableRow>
-                  {headerRow.cells.map((cell) => (
-                    <TableHead key={cell._key}>{cell.content}</TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-            )}
-            <TableBody>
-              {bodyRows.map((row) => (
-                <TableRow key={row._key}>
-                  {row.cells.map((cell) => (
-                    <TableCell key={cell._key}>{cell.content}</TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+        <table>
+          {headerRow && (
+            <thead>
+              <tr>
+                {headerRow.cells.map((cell) => (
+                  <th key={cell._key}>{cell.content}</th>
+                ))}
+              </tr>
+            </thead>
+          )}
+          <tbody>
+            {bodyRows.map((row) => (
+              <tr key={row._key}>
+                {row.cells.map((cell) => (
+                  <td key={cell._key}>{cell.content}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )
     }
   }
@@ -224,7 +214,7 @@ export default function PortableTextBlock({
   ...props
 }: PortableTextProps) {
   return (
-    <div className="prose max-w-none prose-code:rounded prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-a:text-primary prose-bullets:text-foreground prose-code:text-foreground prose-code:text-sm prose-counters:text-foreground prose-headings:text-foreground prose-lead:text-foreground prose-quotes:text-foreground prose-strong:text-foreground text-foreground prose-p:leading-relaxed prose-a:no-underline prose-code:before:content-none prose-code:after:content-none prose-a:hover:underline">
+    <div className="prose prose-theme max-w-none prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
       <PortableText
         {...props}
         components={portableTextComponents}

--- a/apps/portfolio/app/(docs)/layout.tsx
+++ b/apps/portfolio/app/(docs)/layout.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export default function DocsLayout({ children }: LayoutProps<'/'>) {
   return (
     <div className="min-h-dvh px-6 py-16 md:px-12 lg:px-24">
-      <main className="prose mx-auto max-w-3xl prose-a:text-primary prose-headings:text-foreground prose-p:text-muted-foreground prose-strong:text-foreground prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+      <main className="prose prose-theme mx-auto max-w-3xl prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
         {children}
 
         <p className="mt-16">

--- a/apps/portfolio/app/@modal/(.)privacy/page.tsx
+++ b/apps/portfolio/app/@modal/(.)privacy/page.tsx
@@ -28,7 +28,7 @@ export default function PrivacyModal() {
           <DialogTitle>プライバシーポリシー</DialogTitle>
         </DialogHeader>
         <div className="-mx-4 min-h-0 flex-1 overflow-y-auto px-8">
-          <div className="prose prose-base max-w-none prose-a:text-primary prose-headings:text-foreground prose-p:text-base prose-p:text-muted-foreground prose-strong:text-foreground prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+          <div className="prose prose-theme prose-base max-w-none prose-p:text-base prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
             <PrivacyContent />
           </div>
         </div>

--- a/apps/portfolio/app/_components/about.tsx
+++ b/apps/portfolio/app/_components/about.tsx
@@ -31,7 +31,7 @@ async function AboutImpl() {
       <h2 className="mb-10 font-semibold text-base text-muted-foreground uppercase tracking-widest">
         About
       </h2>
-      <div className="prose max-w-none prose-a:text-primary prose-headings:text-foreground prose-p:text-muted-foreground prose-strong:text-foreground prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+      <div className="prose prose-theme max-w-none prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
         <PortableTextBlock value={profile.about} />
       </div>
     </section>

--- a/apps/portfolio/app/_components/portable-text.tsx
+++ b/apps/portfolio/app/_components/portable-text.tsx
@@ -4,15 +4,6 @@ import {
   type PortableTextMarkComponentProps,
   type PortableTextReactComponents
 } from '@portabletext/react'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from '@ykzts/ui/components/table'
-import type React from 'react'
 import { type ComponentProps, Suspense } from 'react'
 import Link from '@/components/link'
 import type { PortableTextValue } from '@/lib/portable-text'
@@ -80,13 +71,6 @@ const portableTextComponents = {
     code: CodeBlockComponent
   },
   marks: {
-    code({ children }: { children: React.ReactNode }) {
-      return (
-        <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
-          {children}
-        </code>
-      )
-    },
     link({
       children,
       value
@@ -112,28 +96,26 @@ const portableTextComponents = {
       const headerRow = hasHeader ? value.rows[0] : null
       const bodyRows = hasHeader ? value.rows.slice(1) : value.rows
       return (
-        <div className="my-6">
-          <Table>
-            {headerRow && (
-              <TableHeader>
-                <TableRow>
-                  {headerRow.cells.map((cell) => (
-                    <TableHead key={cell._key}>{cell.content}</TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-            )}
-            <TableBody>
-              {bodyRows.map((row) => (
-                <TableRow key={row._key}>
-                  {row.cells.map((cell) => (
-                    <TableCell key={cell._key}>{cell.content}</TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+        <table>
+          {headerRow && (
+            <thead>
+              <tr>
+                {headerRow.cells.map((cell) => (
+                  <th key={cell._key}>{cell.content}</th>
+                ))}
+              </tr>
+            </thead>
+          )}
+          <tbody>
+            {bodyRows.map((row) => (
+              <tr key={row._key}>
+                {row.cells.map((cell) => (
+                  <td key={cell._key}>{cell.content}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )
     }
   }

--- a/apps/portfolio/app/_components/works-list.tsx
+++ b/apps/portfolio/app/_components/works-list.tsx
@@ -37,7 +37,7 @@ export default function WorksList({
               {work.title}
             </h3>
             {work.content && (
-              <div className="prose prose-base max-w-none prose-a:text-primary prose-p:text-base prose-p:text-muted-foreground prose-strong:text-foreground prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+              <div className="prose prose-theme prose-base max-w-none prose-p:text-base prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
                 <PortableTextBlock value={work.content} />
               </div>
             )}

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -161,3 +161,22 @@
     @apply bg-primary/20 text-foreground;
   }
 }
+
+@utility prose-theme {
+  --tw-prose-body: var(--color-foreground);
+  --tw-prose-headings: var(--color-foreground);
+  --tw-prose-lead: var(--color-foreground);
+  --tw-prose-links: var(--color-primary);
+  --tw-prose-bold: var(--color-foreground);
+  --tw-prose-counters: var(--color-foreground);
+  --tw-prose-bullets: var(--color-foreground);
+  --tw-prose-hr: var(--color-border);
+  --tw-prose-quotes: var(--color-foreground);
+  --tw-prose-quote-borders: var(--color-border);
+  --tw-prose-captions: var(--color-muted-foreground);
+  --tw-prose-code: var(--color-foreground);
+  --tw-prose-pre-code: var(--color-foreground);
+  --tw-prose-pre-bg: var(--color-muted);
+  --tw-prose-th-borders: var(--color-border);
+  --tw-prose-td-borders: var(--color-border);
+}


### PR DESCRIPTION
## 概要

`@tailwindcss/typography` プラグインの公式ドキュメントに従い、カスタムカラーテーマを正しい方法で実装しました。

## 変更内容

### 1. カスタムテーマを `packages/ui` で共通化
- `packages/ui/src/styles/theme.css` に `@utility prose-theme` を追加
- `--tw-prose-*` カスタムプロパティを使用して色を定義（公式ドキュメント推奨の方法）

### 2. 重複コードの削除
- 各アプリの `globals.css` から重複した `prose-theme` 定義を削除
- DRY原則に従い、共通パッケージでテーマを一元管理

### 3. コンポーネントの修正
- `prose-*:text-*` パターンを `prose-theme` クラスに置き換え
- カスタムスタイル（`code`, `table`）を削除し、typography のデフォルトスタイルを使用
- `table` を shadcn/ui から素の HTML 要素に変更

## 参考
- [@tailwindcss/typography - Adding custom color themes](https://github.com/tailwindlabs/tailwindcss-typography?tab=readme-ov-file#adding-custom-color-themes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * タイポグラフィスタイルを統合化し、複数のユーティリティクラスから単一の`prose-theme`クラスに統合しました。
  * テーブルレンダリングをカスタムコンポーネントからネイティブHTMLに変更しました。

* **Style**
  * CSSテーマユーティリティを追加し、プロザイコンテンツのタイポグラフィスタイルをカプセル化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->