### PR TITLE
build(pnpm): replace to `allowBuilds`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,17 @@ packages:
   - packages/*
   - profile
   - renovate-config
-  - scripts/*
 
 catalog:
   '@next/mdx': 16.2.6
   next: 16.2.6
   typescript: 6.0.3
+
+allowBuilds:
+  @swc/core: true
+  @tailwindcss/oxide: true
+  esbuild: true
+  shape: true
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
@@ -16,9 +21,4 @@ minimumReleaseAgeExclude:
   - eslint-config-next
   - next
   - renovate
-onlyBuiltDependencies:
-  - '@swc/core'
-  - '@tailwindcss/oxide'
-  - esbuild
-  - sharp
 savePrefix: ''

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,8 @@ catalog:
   typescript: 6.0.3
 
 allowBuilds:
-  @swc/core: true
-  @tailwindcss/oxide: true
+  '@swc/core': true
+  '@tailwindcss/oxide': true
   esbuild: true
   shape: true
 


### PR DESCRIPTION
This pull request updates the `pnpm-workspace.yaml` configuration to streamline build and dependency management. The main changes involve replacing the `onlyBuiltDependencies` field with a new `allowBuilds` field and cleaning up package patterns.

Dependency build configuration:

* Replaced the `onlyBuiltDependencies` field with an `allowBuilds` field, explicitly listing `@swc/core`, `@tailwindcss/oxide`, `esbuild`, and `shape` as allowed builds. This change clarifies which dependencies are permitted to be built in the workspace.

Workspace configuration cleanup:

* Removed the inclusion of the `scripts/*` directory from the `packages` list, likely to avoid treating scripts as packages.
* Removed `sharp` from the list of built dependencies, which is now managed via the new `allowBuilds` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ワークスペース構成の最適化により、ビルドシステムの設定を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ykzts/ykzts/pull/3922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->