### PR TITLE
build(deps): update pnpm to v11

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:3.0.1": {
+      "version": "3.0.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9",
+      "integrity": "sha256:ca2508495b01ba29eba93e8153772a2daa65eaa86471cc6863fe2a3d21933df9"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "name": "@ykzts/monorepo",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.5.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,10 +10,15 @@ catalog:
   typescript: 6.0.3
 
 allowBuilds:
-  '@swc/core': true
   '@tailwindcss/oxide': true
+  better-sqlite3: false
+  core-js-pure: false
+  dtrace-provider: false
   esbuild: true
-  shape: true
+  msw: false
+  protobufjs: false
+  re2: false
+  sharp: true
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:


### PR DESCRIPTION
This pull request includes updates to development environment configuration and dependency management. The most notable changes are an upgrade to the `pnpm` package manager, adjustments to allowed builds in the `pnpm-workspace.yaml`, and the addition of a devcontainer lock file specifying development features.

Dependency and build configuration updates:

* Upgraded the `pnpm` package manager from version 10.33.4 to 11.5.0 in `package.json`, ensuring compatibility with newer features and bug fixes.
* Updated the `allowBuilds` section in `pnpm-workspace.yaml` to add or remove certain packages, restricting or allowing local builds as appropriate. Notably, packages like `better-sqlite3`, `core-js-pure`, `dtrace-provider`, `msw`, and `protobufjs` are now set to false, while `sharp` remains allowed.

Development environment enhancements:

* Added a `.devcontainer/devcontainer-lock.json` file to lock versions of devcontainer features such as `docker-in-docker` and `github-cli`, improving reproducibility of the development environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージマネージャーをアップデートしました
  * 開発環境の依存関係を更新しました
  * ビルド設定を調整しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ykzts/ykzts/pull/3924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->