### PR TITLE
refactor(portfolio): inject current date into `getPosts`

### DIFF
--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -5,6 +5,13 @@ import range from '@/lib/range'
 
 const RECENT_POSTS_COUNT = 5
 
+function startOfDay(date: Date): Date {
+  const normalized = new Date(date)
+  normalized.setMinutes(0, 0, 0)
+
+  return normalized
+}
+
 function getDateBasedUrl(slug: string, publishedAt: string): string {
   const date = new Date(publishedAt)
   const year = date.getUTCFullYear()
@@ -41,7 +48,7 @@ async function RecentPostsImpl() {
   let allPosts: Awaited<ReturnType<typeof getPosts>>
 
   try {
-    allPosts = await getPosts()
+    allPosts = await getPosts(1, startOfDay(new Date()))
   } catch (error) {
     console.error('Failed to load recent posts:', error)
     return null

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -1,4 +1,5 @@
 import { getPosts } from '@ykzts/supabase/queries'
+import { cacheLife } from 'next/cache'
 import { Suspense } from 'react'
 import Skeleton from '@/components/skeleton'
 import range from '@/lib/range'
@@ -10,6 +11,14 @@ function startOfHour(date: Date): Date {
   normalized.setMinutes(0, 0, 0)
 
   return normalized
+}
+
+function getCurrentTime(): Date {
+  'use cache'
+
+  cacheLife('hours')
+
+  return startOfHour(new Date())
 }
 
 function getDateBasedUrl(slug: string, publishedAt: string): string {
@@ -44,7 +53,9 @@ function RecentPostsSkeleton() {
   )
 }
 
-async function RecentPostsImpl({ now }: { now: Date }) {
+async function RecentPostsImpl() {
+  const now = getCurrentTime()
+
   let allPosts: Awaited<ReturnType<typeof getPosts>>
 
   try {
@@ -130,8 +141,6 @@ async function RecentPostsImpl({ now }: { now: Date }) {
 }
 
 export default function RecentPosts() {
-  const now = startOfHour(new Date())
-
   return (
     <Suspense fallback={<RecentPostsSkeleton />}>
       <RecentPostsImpl now={now} />

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -13,7 +13,7 @@ function startOfHour(date: Date): Date {
   return normalized
 }
 
-async function getCurrentTime(): Date {
+async function getCurrentTime(): Promise<Date> {
   'use cache'
 
   cacheLife('hours')

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -143,7 +143,7 @@ async function RecentPostsImpl() {
 export default function RecentPosts() {
   return (
     <Suspense fallback={<RecentPostsSkeleton />}>
-      <RecentPostsImpl now={now} />
+      <RecentPostsImpl />
     </Suspense>
   )
 }

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -5,7 +5,7 @@ import range from '@/lib/range'
 
 const RECENT_POSTS_COUNT = 5
 
-function startOfDay(date: Date): Date {
+function startOfHour(date: Date): Date {
   const normalized = new Date(date)
   normalized.setMinutes(0, 0, 0)
 
@@ -44,11 +44,11 @@ function RecentPostsSkeleton() {
   )
 }
 
-async function RecentPostsImpl() {
+async function RecentPostsImpl({ now }: { now: Date }) {
   let allPosts: Awaited<ReturnType<typeof getPosts>>
 
   try {
-    allPosts = await getPosts(1, startOfDay(new Date()))
+    allPosts = await getPosts(1, now)
   } catch (error) {
     console.error('Failed to load recent posts:', error)
     return null
@@ -130,9 +130,11 @@ async function RecentPostsImpl() {
 }
 
 export default function RecentPosts() {
+  const now = startOfHour(new Date())
+
   return (
     <Suspense fallback={<RecentPostsSkeleton />}>
-      <RecentPostsImpl />
+      <RecentPostsImpl now={now} />
     </Suspense>
   )
 }

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -13,7 +13,7 @@ function startOfHour(date: Date): Date {
   return normalized
 }
 
-function getCurrentTime(): Date {
+async function getCurrentTime(): Date {
   'use cache'
 
   cacheLife('hours')
@@ -54,7 +54,7 @@ function RecentPostsSkeleton() {
 }
 
 async function RecentPostsImpl() {
-  const now = getCurrentTime()
+  const now = await getCurrentTime()
 
   let allPosts: Awaited<ReturnType<typeof getPosts>>
 

--- a/packages/supabase/src/queries.ts
+++ b/packages/supabase/src/queries.ts
@@ -207,7 +207,7 @@ export async function getWorks(): Promise<Work[]> {
  * Returns an empty array when Supabase is not configured, so listing pages can
  * still render without a profile dependency.
  */
-export async function getPosts(page = 1): Promise<Post[]> {
+export async function getPosts(page = 1, now = new Date()): Promise<Post[]> {
   'use cache'
 
   cacheTag('posts')
@@ -244,7 +244,7 @@ export async function getPosts(page = 1): Promise<Post[]> {
       `
     )
     .eq('status', 'published')
-    .lte('published_at', new Date().toISOString())
+    .lte('published_at', now.toISOString())
     .order('published_at', { ascending: false })
     .range(offset, offset + POSTS_PER_PAGE - 1)
 


### PR DESCRIPTION
This pull request updates how recent posts are fetched and filtered in the portfolio app, ensuring posts are only shown if published before the start of the current day. It also includes minor improvements to configuration and query parameterization.

**Recent Posts Filtering Logic:**
- Added a `startOfDay` function in `recent-posts.tsx` to normalize the current date to midnight, ensuring only posts published before today are retrieved.
- Updated the `RecentPostsImpl` component to call `getPosts` with the normalized current date, improving the accuracy of recent post listings.

**Query Parameterization:**
- Modified `getPosts` in `queries.ts` to accept a `now` parameter (defaults to current date), making the function more flexible and testable.
- Updated the Supabase query in `getPosts` to use the provided `now` parameter instead of always using the current time, ensuring consistent filtering based on the caller's context.

**Configuration Improvements:**
- Updated `biome.jsonc` to exclude additional files and directories from formatting and linting, such as `.agents`, `skills-lock.json`, and others, for better tooling performance and accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 投稿取得時の日付処理を改善し、より正確な投稿フィルタリングを実現しました。

* **Chores**
  * 開発ツールの設定を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ykzts/ykzts/pull/3927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->