### PR TITLE
build(biome): add exclude paths

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,9 +27,11 @@
   "files": {
     "includes": [
       "**",
+      "!.agents/**/*",
       "!.devcontainer/devcontainer-lock.json",
       "!packages/supabase/src/database.types.ts",
-      "!packages/ui/src/components/**/*.{ts,tsx}"
+      "!packages/ui/src/components/**/*.{ts,tsx}",
+      "!skills-lock.json"
     ]
   },
   "formatter": {


### PR DESCRIPTION
This pull request updates the `biome.jsonc` configuration to exclude additional files and directories from processing. The most important change is the adjustment of the `includes` list to ignore certain files and directories.

Configuration updates:

* Excluded the `.agents` directory and all its contents from being processed.
* Excluded the `skills-lock.json` file from being processed.