### PR TITLE
build(devcontainer): add volume mount for node_modules in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
     "cpus": 4
   },
   "image": "mcr.microsoft.com/devcontainers/typescript-node:4-24-bookworm",
+  "mounts": [
+    "source=ykzts-com-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+  ],
   "name": "ykzts.com",
   "postCreateCommand": "./.devcontainer/post-create.sh"
 }


### PR DESCRIPTION
This pull request makes a configuration update to the development container setup. The most important change is the addition of a volume mount for `node_modules`, which helps persist installed node modules across container rebuilds.

Dev container configuration:

* Added a `mounts` entry to `.devcontainer/devcontainer.json` to persist `node_modules` using a named Docker volume, improving development workflow by avoiding repeated dependency installations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境のコンテナ設定において、`node_modules` をボリュームマウントするよう設定を更新しました。これにより開発環境の初期化処理が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->