### PR TITLE
feat: replace to `@vercel/microfrontends`

### DIFF
--- a/.agents/skills/vercel-microfrontends/README.md
+++ b/.agents/skills/vercel-microfrontends/README.md
@@ -1,0 +1,25 @@
+# Vercel Microfrontends
+
+An agent skill for building, configuring, and deploying microfrontends on Vercel.
+
+## Structure
+
+- `SKILL.md` - Core skill with concepts, quickstart, and pointers to references
+- `references/` - Detailed reference documentation
+  - `configuration.md` - `microfrontends.json` schema, field details, naming, examples
+  - `path-routing.md` - Path expressions, asset prefixes, flag-controlled routing
+  - `local-development.md` - Local proxy setup, polyrepo config, deployment protection
+  - `managing-microfrontends.md` - Adding/removing projects, fallbacks, navigation, observability
+  - `troubleshooting.md` - Testing utilities, debug headers, common issues
+- `metadata.json` - Skill metadata (skill version, organization, references)
+
+## Install
+
+```bash
+npx skills add vercel/microfrontends
+```
+
+## Learn More
+
+- [Vercel Microfrontends Docs](https://vercel.com/docs/microfrontends)
+- [`@vercel/microfrontends` on npm](https://www.npmjs.com/package/@vercel/microfrontends)

--- a/.agents/skills/vercel-microfrontends/SKILL.md
+++ b/.agents/skills/vercel-microfrontends/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: vercel-microfrontends
+description: Guide for building, configuring, and deploying microfrontends on Vercel. Use this skill when the user mentions microfrontends, multi-zones, splitting an app across teams, independent deployments, cross-app routing, incremental migration, composing multiple frontends under one domain, microfrontends.json, @vercel/microfrontends, the microfrontends local proxy, or path-based routing between Vercel projects. Also use when the user asks about shared layouts across projects, navigation between microfrontends, fallback environments, asset prefixes, or feature flag controlled routing.
+license: MIT
+metadata:
+  author: vercel
+  version: "1.0.0"
+---
+
+# Vercel Microfrontends
+Split a large application into independently deployable units that render as one cohesive app. Vercel handles routing on its global network using `microfrontends.json`.
+
+**Core concepts:** default app (has `microfrontends.json`, serves unmatched requests) · child apps (have `routing` path patterns) · asset prefix (prevents static-asset collisions) · independent deployments.
+
+**Frameworks:** Next.js (App Router + Pages Router), SvelteKit, React Router, Vite — all via `@vercel/microfrontends`.
+
+**CLI (`vercel microfrontends` / `vercel mf`):**
+- `create-group` — create a new group; interactive by default, or fully non-interactive with `--non-interactive` (options: `--name`, `--project` (repeatable), `--default-app`, `--default-route`, `--project-default-route` (repeatable, format: `<project>=<route>`, required for each non-default project in non-interactive mode), `--yes` to skip confirmation prompt); note: `--non-interactive` is blocked if adding the projects would exceed the free tier limit — the user must confirm billing changes interactively
+- `add-to-group` — add the current project to an existing group; requires interactive terminal (options: `--group`, `--default-route`)
+- `remove-from-group` — remove the current project from its group; requires interactive terminal (option: `--yes` skips project-link prompt only)
+- `delete-group` — delete a group and all its settings, irreversible; requires interactive terminal (option: `--group` to pre-select group)
+- `pull` — pull remote `microfrontends.json` for local development (option: `--dpl`)
+- `microfrontends proxy` — local dev proxy · `microfrontends port` — print auto-assigned port
+
+## Finding Detailed Information
+
+This skill includes detailed reference docs in the `references/` directory. **Do not read all references upfront.** Instead, search or grep the relevant file when the user asks about a specific topic:
+
+| Topic | Reference file |
+|---|---|
+| Getting started, quickstart, framework setup, `microfrontends.json` schema, fields, naming, examples | `references/configuration.md` |
+| Path expressions, asset prefixes, flag-controlled routing, middleware | `references/path-routing.md` |
+| Local proxy setup, polyrepo config, Turborepo, ports, deployment protection | `references/local-development.md` |
+| Inspecting groups (`inspect-group`), adding/removing projects, fallback environments, navigation, observability | `references/managing-microfrontends.md` |
+| Testing utilities (`validateMiddlewareConfig`, `validateRouting`, etc.), debug headers, common issues | `references/troubleshooting.md` |
+| Deployment protection, Vercel Firewall, WAF rules for microfrontends | `references/security.md` |
+
+When the user asks about a specific topic, use grep or search over the relevant reference file to find the answer without loading all references into context.

--- a/.agents/skills/vercel-microfrontends/metadata.json
+++ b/.agents/skills/vercel-microfrontends/metadata.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0",
+  "organization": "Vercel",
+  "date": "February 2026",
+  "abstract": "Guide for building, configuring, and deploying microfrontends on Vercel. Covers configuration (microfrontends.json), path-based routing, flag-controlled routing, local development proxy, asset prefixes, and framework integrations for Next.js, SvelteKit, React Router, and Vite. Includes reference documentation for configuration schema, path expressions, local development, managing microfrontends, and troubleshooting.",
+  "references": [
+    "https://vercel.com/docs/microfrontends",
+    "https://vercel.com/docs/microfrontends/quickstart",
+    "https://vercel.com/docs/microfrontends/configuration",
+    "https://vercel.com/docs/microfrontends/path-routing",
+    "https://vercel.com/docs/microfrontends/local-development",
+    "https://vercel.com/docs/microfrontends/managing-microfrontends",
+    "https://vercel.com/docs/microfrontends/troubleshooting",
+    "https://vercel.com/docs/microfrontends/managing-microfrontends/security",
+    "https://www.npmjs.com/package/@vercel/microfrontends"
+  ]
+}

--- a/.agents/skills/vercel-microfrontends/references/configuration.md
+++ b/.agents/skills/vercel-microfrontends/references/configuration.md
@@ -1,0 +1,217 @@
+# Configuration Reference
+
+The `microfrontends.json` file is the single source of truth for microfrontend routing. It must be deployed with the default application.
+
+## Getting Started
+
+1. **Create a microfrontends group** using the CLI (`vercel microfrontends create-group`) or the Vercel Dashboard: Settings → Microfrontends → Create Group.
+2. **Inspect the group** (optional but recommended for automation): `vercel mf inspect-group --group="<name>" --format=json` returns project names, frameworks, git repos, and root directories needed for the remaining steps.
+3. **Add `microfrontends.json`** at the root of the default application (see [Full Schema](#full-schema) and [Example Configurations](#example-configurations)).
+4. **Install** in every microfrontend: `pnpm i @vercel/microfrontends`
+5. **Integrate with your framework** — add `withMicrofrontends` (Next.js/SvelteKit) or the `microfrontends()` Vite plugin to each app's config (see [Framework Setup](#framework-setup)).
+6. **Deploy** — push to Vercel. Config takes effect once `microfrontends.json` is deployed to production.
+
+> **Note:** If the user has already created the group (step 1), the immediate next steps are to set up `microfrontends.json` (step 3), install `@vercel/microfrontends` (step 4), and add the framework integration (step 5) in each project. Do not skip these — the group alone does nothing without the config and framework wiring.
+
+## Framework Setup
+
+### Next.js
+
+```ts
+// next.config.ts
+import { withMicrofrontends } from '@vercel/microfrontends/next/config';
+export default withMicrofrontends(nextConfig);
+```
+
+For Pages Router support:
+
+```ts
+export default withMicrofrontends(nextConfig, { supportPagesRouter: true });
+```
+
+### SvelteKit
+
+Wrap the SvelteKit config with `withMicrofrontends` from `@vercel/microfrontends/experimental/sveltekit` and add the `microfrontends()` Vite plugin from `@vercel/microfrontends/experimental/vite`.
+
+### React Router / Vite
+
+Add the `microfrontends()` Vite plugin from `@vercel/microfrontends/experimental/vite`.
+
+## Full Schema
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json",
+  "version": "1",
+  "applications": {
+    "<default-app-name>": {
+      "packageName": "<optional: name from package.json if different>",
+      "development": {
+        "fallback": "<required: production URL for fallback>",
+        "local": "<optional: port number or host for local dev>",
+        "task": "<optional: dev script name, default 'dev'>"
+      }
+    },
+    "<child-app-name>": {
+      "packageName": "<optional: name from package.json if different>",
+      "assetPrefix": "<optional: custom asset prefix>",
+      "routing": [
+        {
+          "group": "<optional: group name>",
+          "flag": "<optional: feature flag name>",
+          "paths": ["/path/:path*"]
+        }
+      ],
+      "development": {
+        "local": "<optional: port or host>",
+        "task": "<optional: dev script name>",
+        "fallback": "<optional: overrides default app fallback>"
+      }
+    }
+  },
+  "options": {
+    "localProxyPort": 3024,
+    "disableOverrides": false
+  }
+}
+```
+
+## Field Details
+
+### `applications` (required)
+
+A map of Vercel project names to their configurations. Keys must match the Vercel project name.
+
+**One application must be the default app** — identified by not having a `routing` field. There must be exactly one.
+
+### Default Application
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `development.fallback` | `string` | Yes | Production URL used as fallback for apps not running locally. Include host only (e.g., `myapp.vercel.app`). Protocol defaults to HTTPS. |
+| `development.local` | `number \| string` | No | Port or host for local dev. Default: auto-assigned based on app name. |
+| `development.task` | `string` | No | Script name from `package.json` to run for dev. Default: `"dev"`. |
+| `packageName` | `string` | No | Set if Vercel project name differs from `package.json` `name` field. |
+
+### Child Application
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `routing` | `PathGroup[]` | Yes | Array of path groups that route to this app. |
+| `assetPrefix` | `string` | No | Custom asset prefix. Default: auto-generated `vc-ap-<hash>`. |
+| `development.local` | `number \| string` | No | Port or host for local dev. |
+| `development.task` | `string` | No | Dev script name. |
+| `development.fallback` | `string` | No | Override fallback URL. Defaults to the default app's fallback. |
+| `packageName` | `string` | No | Set if project name differs from `package.json` `name`. |
+
+### PathGroup
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `paths` | `string[]` | Yes | Path expressions routed to this app. |
+| `group` | `string` | No | Descriptive group name. |
+| `flag` | `string` | No | Feature flag name controlling routing for this group. |
+
+### `options`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `localProxyPort` | `number` | `3024` | Port for the local development proxy. |
+| `disableOverrides` | `boolean` | `false` | Disable routing overrides in the Vercel Toolbar. |
+
+## Application Naming
+
+Application keys in `microfrontends.json` must match Vercel project names. If the project name differs from the `name` field in the app's `package.json`, set `packageName`:
+
+```json
+{
+  "applications": {
+    "docs": {
+      "packageName": "my-docs-package",
+      "routing": [
+        { "paths": ["/docs/:path*"] }
+      ]
+    }
+  }
+}
+```
+
+## File Naming
+
+- Default names: `microfrontends.json` or `microfrontends.jsonc`
+- Custom name via env var: `VC_MICROFRONTENDS_CONFIG_FILE_NAME`
+  - Must end with `.json` or `.jsonc`
+  - May include a path: `/path/to/microfrontends.json`
+  - Path is relative to the root directory of the default application
+  - Add this env var to **all projects** in the microfrontends group
+
+Using a custom file name allows the same repository to support multiple microfrontends groups.
+
+**With Turborepo:** Define the env var outside the Turbo invocation:
+
+```bash
+VC_MICROFRONTENDS_CONFIG_FILE_NAME="microfrontends-dev.json" turbo dev
+```
+
+## Example Configurations
+
+### Minimal (two Next.js apps)
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json",
+  "applications": {
+    "web": {
+      "development": {
+        "fallback": "web-production.vercel.app"
+      }
+    },
+    "docs": {
+      "routing": [
+        { "paths": ["/docs/:path*"] }
+      ]
+    }
+  }
+}
+```
+
+### With custom ports, flags, and asset prefix
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json",
+  "applications": {
+    "marketing": {
+      "development": {
+        "local": 3000,
+        "fallback": "marketing.vercel.app"
+      }
+    },
+    "docs": {
+      "assetPrefix": "docs-assets",
+      "development": { "local": 3001 },
+      "routing": [
+        {
+          "group": "docs",
+          "paths": ["/docs/:path*", "/docs-assets/:path*"]
+        },
+        {
+          "group": "flagged-docs",
+          "flag": "enable-new-docs",
+          "paths": ["/new-docs/:path*"]
+        }
+      ]
+    }
+  }
+}
+```
+
+## JSON Schema Validation
+
+Use the schema URL for editor autocompletion and validation:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json"
+}
+```

--- a/.agents/skills/vercel-microfrontends/references/local-development.md
+++ b/.agents/skills/vercel-microfrontends/references/local-development.md
@@ -1,0 +1,225 @@
+# Local Development Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Application Setup](#application-setup)
+- [Starting the Local Proxy](#starting-the-local-proxy)
+- [Monorepo with Turborepo](#monorepo-with-turborepo)
+- [Without Turborepo](#without-turborepo)
+- [Polyrepo Setup](#polyrepo-setup)
+- [Proxy Command Reference](#proxy-command-reference)
+- [Port Configuration](#port-configuration)
+- [Debug Routing](#debug-routing)
+- [Protected Deployment Fallbacks](#protected-deployment-fallbacks)
+
+## Overview
+
+The `@vercel/microfrontends` local development proxy routes requests between locally running microfrontends and production fallbacks. This allows developers to run only the microfrontend they're working on while still being able to navigate the full application.
+
+**How it works:**
+
+- The proxy listens on a single port (default `3024`)
+- Requests matching a child app's routing paths are sent to the local dev server (if running) or to the production fallback
+- Requests not matching any child app go to the default app
+
+> **Warning (Next.js):** Traffic a child application receives directly will be redirected to the local proxy. Set `MFE_DISABLE_LOCAL_PROXY_REWRITE=1` to disable this.
+
+## Application Setup
+
+Configure each app's dev server to use the auto-assigned port so the proxy knows where to route:
+
+```json
+{
+  "name": "web",
+  "scripts": {
+    "dev": "next dev --port $(microfrontends port)"
+  },
+  "dependencies": {
+    "@vercel/microfrontends": "latest"
+  }
+}
+```
+
+### Custom ports
+
+Set a specific port in `microfrontends.json`:
+
+```json
+{
+  "applications": {
+    "docs": {
+      "routing": [{ "paths": ["/docs/:path*"] }],
+      "development": {
+        "local": 3001
+      }
+    }
+  }
+}
+```
+
+The `local` field accepts:
+
+- A port number: `3001`
+- A host: `my.localhost.me:3001`
+- A full URL: `https://my.localhost.me:3030`
+
+### packageName mapping
+
+If the Vercel project name differs from `package.json` `name`:
+
+```json
+{
+  "applications": {
+    "docs": {
+      "packageName": "my-docs-package",
+      "routing": [{ "paths": ["/docs/:path*"] }]
+    }
+  }
+}
+```
+
+## Starting the Local Proxy
+
+### Monorepo with Turborepo
+
+The proxy starts automatically when running a dev task with `turbo`:
+
+```bash
+turbo run dev --filter=web
+```
+
+This starts the `web` dev server and a proxy routing other microfrontends to production fallbacks.
+
+> Requires `turbo` version `2.3.6` or `2.4.2` or newer.
+
+Turborepo infers configuration from `microfrontends.json`, so no additional Turbo config is needed for microfrontends.
+
+### Without Turborepo
+
+Start the proxy manually:
+
+```json
+{
+  "scripts": {
+    "dev": "next dev --port $(microfrontends port)",
+    "proxy": "microfrontends proxy microfrontends.json --local-apps web"
+  }
+}
+```
+
+Run both `dev` and `proxy` scripts simultaneously.
+
+### Accessing the proxy
+
+Visit the proxy URL shown in terminal output (default `http://localhost:3024`).
+
+Change the port in `microfrontends.json`:
+
+```json
+{
+  "options": {
+    "localProxyPort": 4001
+  }
+}
+```
+
+## Polyrepo Setup
+
+For separate repositories, the `microfrontends.json` file won't be auto-detected. You need to make it available to each repo.
+
+### Option 1: Vercel CLI
+
+```bash
+vercel microfrontends pull
+```
+
+Downloads `microfrontends.json` from your default application. Requires Vercel CLI 44.2.2+.
+
+### Option 2: Environment variable
+
+```bash
+export VC_MICROFRONTENDS_CONFIG=/path/to/microfrontends.json
+```
+
+Or in `.env`:
+
+```
+VC_MICROFRONTENDS_CONFIG=/path/to/microfrontends.json
+```
+
+### Running in polyrepo
+
+1. Start your local microfrontend dev server (e.g., `next dev --port $(microfrontends port)`)
+2. In the same or separate terminal, start the proxy:
+
+```bash
+microfrontends proxy --local-apps your-app-name
+```
+
+3. Visit the proxy URL (default `http://localhost:3024`)
+
+## Proxy Command Reference
+
+```
+microfrontends proxy [configPath] --local-apps <names...> [--port <port>]
+```
+
+| Argument/Flag             | Description                                                           |
+| ------------------------- | --------------------------------------------------------------------- |
+| `[configPath]`            | Path to `microfrontends.json`. Optional in monorepos (auto-detected). |
+| `--local-apps <names...>` | Space-separated list of locally running app names.                    |
+| `--port <port>`           | Override the proxy port.                                              |
+
+Example with multiple local apps:
+
+```bash
+microfrontends proxy microfrontends.json --local-apps web docs
+```
+
+## Port Configuration
+
+```
+microfrontends port
+```
+
+Prints the auto-assigned development port for the current application. The port is deterministic based on the application name and the microfrontends configuration.
+
+Use in `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "next dev --port $(microfrontends port)"
+  }
+}
+```
+
+## Debug Routing
+
+Enable debug logs to see where and why the proxy routed each request:
+
+1. Set environment variable `MFE_DEBUG=1`, **or**
+2. Pass `debug: true` to `withMicrofrontends`:
+
+```ts
+export default withMicrofrontends(nextConfig, { debug: true });
+```
+
+Debug output shows:
+
+- Environment variables set by microfrontends
+- Rewrites configured
+- For each request: matched path, target application, local vs fallback
+
+## Protected Deployment Fallbacks
+
+To fall back to deployments with [Deployment Protection](https://vercel.com/docs/deployment-protection), set a bypass environment variable.
+
+The local proxy reads `VERCEL_AUTOMATION_BYPASS_SECRET` from the default app's environment (Vercel sets this automatically as a system environment variable) and sends its value as the `x-vercel-protection-bypass` header when proxying to protected child project deployments.
+
+### Setup steps
+
+1. **Find the default app's secret**: in the default app's Vercel project, go to Settings → Deployment Protection → Protection Bypass for Automation → copy the secret (this is what Vercel exposes as `VERCEL_AUTOMATION_BYPASS_SECRET`)
+2. **Add that secret to each child project**: in each child project's Vercel project, go to Settings → Deployment Protection → add a Protection Bypass for Automation secret using the same value
+3. **Set locally**: add `VERCEL_AUTOMATION_BYPASS_SECRET=<secret>` to the default app's local environment file (e.g. `.env.local`)

--- a/.agents/skills/vercel-microfrontends/references/managing-microfrontends.md
+++ b/.agents/skills/vercel-microfrontends/references/managing-microfrontends.md
@@ -1,0 +1,215 @@
+# Managing Microfrontends Reference
+
+## Table of Contents
+
+- [Inspecting a Group](#inspecting-a-group)
+- [Adding Microfrontends](#adding-microfrontends)
+- [Removing Microfrontends](#removing-microfrontends)
+- [Deleting a Group](#deleting-a-group)
+- [Fallback Environment](#fallback-environment)
+- [Sharing Settings](#sharing-settings)
+- [Optimizing Navigations](#optimizing-navigations)
+- [Observability Data Routing](#observability-data-routing)
+
+## Inspecting a Group
+
+Use `vercel microfrontends inspect-group` to retrieve metadata about a microfrontends group and its projects. This is useful for setup automation and scripts — it provides the project names, frameworks, git repos, and root directories needed to generate `microfrontends.json` and wire up framework integrations.
+
+```bash
+vercel microfrontends inspect-group [options]
+```
+
+If you omit `--group`, the command is interactive and lets you select a group. In non-interactive environments, pass `--group`.
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--group` | Name, slug, or ID of the microfrontends group to inspect |
+| `--config-file-name` | Custom microfrontends config file path/name relative to the default app root (must end with `.json` or `.jsonc`) |
+| `--format` | Output format. Use `json` for machine-readable output |
+
+### Examples
+
+```bash
+# Interactive selection
+vercel microfrontends inspect-group
+
+# JSON output for scripting/agents
+vercel mf inspect-group --group="My Group" --format=json
+
+# With a custom config filename
+vercel mf inspect-group --group="My Group" --config-file-name=microfrontends.jsonc --format=json
+```
+
+> **Tip for agents:** After the user creates a group, run `vercel mf inspect-group --group="<name>" --format=json` to get the project metadata needed to automate the remaining setup (generating `microfrontends.json`, installing `@vercel/microfrontends`, and adding framework integrations).
+
+## Adding Microfrontends
+
+**CLI:** run from the project directory and follow the prompts:
+
+```bash
+vercel microfrontends add-to-group
+# or with flags:
+vercel mf add-to-group --group="My Group" --default-route=/docs
+```
+
+**Dashboard:** Settings → Microfrontends → find the group → **Add to Group**.
+
+Changes take effect on the next deployment.
+
+## Removing Microfrontends
+
+**CLI:** run from the project directory and follow the prompts:
+
+```bash
+vercel microfrontends remove-from-group
+```
+
+After removal, update `microfrontends.json` in the default app to remove the project's entry — the CLI will warn you if it's still referenced but won't block the removal.
+
+**Dashboard:**
+1. Remove the microfrontend from `microfrontends.json` in the default app
+2. Visit **Settings** for the project
+3. Click **Microfrontends** → **Remove from Group**
+
+> The default application can only be removed after all other projects in the group are removed.
+
+## Deleting a Group
+
+This action is not reversible. You can delete a group even with projects still in it — all projects will be removed from the group automatically.
+
+**CLI:** run from the project directory and follow the prompts:
+
+```bash
+vercel microfrontends delete-group
+# or pre-select the group with a flag:
+vercel mf delete-group --group="My Group"
+```
+
+**Dashboard:** Go to the group's settings in **Settings** → **Microfrontends** and delete the group.
+
+## Fallback Environment
+
+Controls where requests are routed when a microfrontend isn't built for a specific commit. This applies to Preview and Custom environments only — production always routes to each project's production deployment.
+
+### Options
+
+| Setting | Behavior |
+|---|---|
+| `Same Environment` | Falls back to a deployment in the same environment for the other project. Vercel auto-generates Preview deployments on the production branch. |
+| `Production` | Falls back to the promoted Production deployment of the other project. |
+| Custom environment name | Falls back to a deployment in the specified custom environment. |
+
+### Fallback behavior matrix
+
+| Current Environment | Fallback Setting | Built for Commit | Not Built for Commit |
+|---|---|---|---|
+| Preview | Same Environment | Preview | Preview |
+| Preview | Production | Preview | Production |
+| Preview | `staging` | Preview | `staging` |
+| `staging` | Same Environment | `staging` | `staging` |
+| `staging` | Production | `staging` | Production |
+
+Configure in **Settings** → Microfrontends group → **Fallback Environment**.
+
+> If using Same Environment or Custom Environment, ensure those environments have deployments to fall back to. Missing fallbacks cause `MICROFRONTENDS_MISSING_FALLBACK_ERROR`.
+
+### Branch domain fallbacks
+
+If a project has a domain assigned to a Git branch and fallback is set to Same Environment, deployments on that branch use the branch's project domain as fallback instead of the production branch. Add the branch domain to every project in the group.
+
+## Sharing Settings
+
+Use the [Vercel Terraform Provider](https://registry.terraform.io/providers/vercel/vercel/latest/docs) to synchronize settings across projects:
+
+- [Microfrontend group resource](https://registry.terraform.io/providers/vercel/vercel/latest/docs/resources/microfrontend_group)
+- [Microfrontend group membership resource](https://registry.terraform.io/providers/vercel/vercel/latest/docs/resources/microfrontend_group_membership)
+
+### Sharing environment variables
+
+Use [Shared Environment Variables](https://vercel.com/docs/environment-variables/shared-environment-variables) to manage secrets across projects.
+
+For same-name variables with different values per group, create a shared var with a unique name (e.g., `FLAG_SECRET_X`) then map it: `FLAG_SECRET=$FLAG_SECRET_X` in `.env` or build command.
+
+## Optimizing Navigations
+
+> **Note:** Currently only supported for Next.js.
+
+Navigations between top-level microfrontends cause hard navigations. Vercel optimizes these by prefetching and prerendering cross-zone links.
+
+### Setup for Next.js App Router
+
+Add `PrefetchCrossZoneLinks` to your root layout in **all** microfrontend apps:
+
+```tsx
+// app/layout.tsx
+import { PrefetchCrossZoneLinks } from '@vercel/microfrontends/next/client';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <PrefetchCrossZoneLinks />
+      </body>
+    </html>
+  );
+}
+```
+
+`PrefetchCrossZoneLinks` accepts an optional `prerenderEagerness` prop (`'immediate' | 'eager' | 'moderate' | 'conservative'`, default `'conservative'`) that controls how aggressively cross-zone pages are prerendered in the background.
+
+### Setup for Next.js Pages Router
+
+Add `PrefetchCrossZoneLinks` to `_app.tsx`:
+
+```tsx
+// pages/_app.tsx
+import { PrefetchCrossZoneLinks } from '@vercel/microfrontends/next/client';
+
+export default function App({ Component, pageProps }) {
+  return (
+    <>
+      <Component {...pageProps} />
+      <PrefetchCrossZoneLinks />
+    </>
+  );
+}
+```
+
+### Using the Link component
+
+Use the microfrontends `Link` component instead of regular anchors for cross-zone links:
+
+```tsx
+import { Link } from '@vercel/microfrontends/next/client';
+
+export function Navigation() {
+  return (
+    <nav>
+      <Link href="/docs">Docs</Link>
+      <Link href="/blog">Blog</Link>
+    </nav>
+  );
+}
+```
+
+> **Note:** All paths from `microfrontends.json` become visible on the client side when using this feature.
+
+## Observability Data Routing
+
+By default, Speed Insights and Analytics data routes to the default application.
+
+To route a project's data to its own Vercel project page:
+
+1. Update dependencies:
+   - `@vercel/speed-insights` ≥ `1.2.0`
+   - `@vercel/analytics` ≥ `1.5.0`
+2. Go to **Settings** → **Microfrontends** for the project
+3. Find **Observability Routing** and enable it
+4. Takes effect on the next production deployment
+
+> Toggling does not move historical data.
+
+If using Turborepo with `--env-mode=strict`, add `ROUTE_OBSERVABILITY_TO_THIS_PROJECT` and `NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH` to allowed env vars, or use `--env-mode=loose`.

--- a/.agents/skills/vercel-microfrontends/references/path-routing.md
+++ b/.agents/skills/vercel-microfrontends/references/path-routing.md
@@ -1,0 +1,184 @@
+# Path Routing Reference
+
+Vercel handles routing to microfrontends directly in its network infrastructure. When a request arrives at a domain using microfrontends, the `microfrontends.json` file from the live deployment determines which microfrontend handles it.
+
+## Adding a New Path
+
+Modify the `routing` section for the target application in `microfrontends.json`:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json",
+  "applications": {
+    "web": {
+      "development": {
+        "fallback": "web.vercel.app"
+      }
+    },
+    "docs": {
+      "routing": [
+        {
+          "paths": ["/docs/:path*", "/new-path-to-route"]
+        }
+      ]
+    }
+  }
+}
+```
+
+The routing change takes effect when the deployment is live. Test in Preview first.
+
+> **Important:** Changes to separate microfrontends are not rolled out in lockstep. Ensure the target application can handle the requests before merging the config change. Use [flags](#flag-controlled-routing) to control rollout safely.
+
+Use [Instant Rollback](https://vercel.com/docs/instant-rollback) to revert routing changes.
+
+## Supported Path Expressions
+
+| Expression | Description | Example Match |
+|---|---|---|
+| `/path` | Constant path | `/path` |
+| `/:path` | Single path segment wildcard | `/anything` |
+| `/:path/suffix` | Single segment with suffix | `/anything/suffix` |
+| `/prefix/:path*` | Zero or more segments | `/prefix`, `/prefix/a`, `/prefix/a/b` |
+| `/prefix/:path+` | One or more segments | `/prefix/a`, `/prefix/a/b` |
+| `/\\(a\\)` | Escaped special characters | `/(a)` |
+| `/:path(a\|b)` | Alternation | `/a` or `/b` |
+| `/:path(a\|\\(b\\))` | Alternation with escaped chars | `/a` or `/(b)` |
+| `/:path((?!a\|b).*)` | Negative lookahead | Any single segment except `/a` or `/b` |
+| `/prefix-:path-suffix` | Inline wildcard with prefix/suffix | `/prefix-anything-suffix` |
+
+### Not Supported
+
+- Conflicting or overlapping paths (paths must uniquely map to one microfrontend)
+- Regular expressions beyond the patterns listed above
+- Wildcards matching multiple segments (`+`, `*`) that don't come at the end of the expression
+
+Use the [`validateRouting` test utility](https://vercel.com/docs/microfrontends/troubleshooting#validaterouting) to verify path expressions resolve to the correct microfrontend.
+
+## Asset Prefix
+
+An asset prefix is a unique path prefix for static assets (JS, CSS, images) to prevent URL collisions between microfrontends.
+
+### Auto-generated (default)
+
+When using `withMicrofrontends`, a default prefix of `vc-ap-<hash>` is generated automatically (obfuscated hash of the project name).
+
+### Custom asset prefix
+
+Set `assetPrefix` in `microfrontends.json`:
+
+```json
+"your-application": {
+  "assetPrefix": "marketing-assets",
+  "routing": [
+    {
+      "paths": ["/marketing/:path*", "/marketing-assets/:path*"]
+    }
+  ]
+}
+```
+
+> **Warning:** Changing the asset prefix after deployment is not guaranteed to be backwards compatible. Route the new prefix in production before updating the `assetPrefix` field.
+
+### Next.js asset notes
+
+JavaScript and CSS URLs are automatically prefixed, but content in the `public/` directory must be manually moved to a subdirectory named with the asset prefix.
+
+## Setting a Default Route
+
+Microfrontend child app deployments may not serve content at `/`. Set a default route in the dashboard so links point to a valid path:
+
+1. Open **Settings** → **Microfrontends** for your project
+2. Find **Default Route**
+3. Enter a path like `/docs` and save
+
+## Routing to External Applications
+
+For microfrontends not yet on Vercel, create a Vercel project that rewrites requests to the external host, then use that project in `microfrontends.json`.
+
+## Flag-Controlled Routing
+
+> **Note:** Only compatible with Next.js.
+
+Use flags to dynamically control routing. Instead of automatic routing, requests go to the default app which decides via middleware whether to route to the microfrontend.
+
+### Step 1: Add flag to config
+
+```json
+{
+  "applications": {
+    "web": {
+      "development": {
+        "fallback": "web.vercel.app"
+      }
+    },
+    "docs": {
+      "routing": [
+        {
+          "flag": "name-of-feature-flag",
+          "paths": ["/flagged-path"]
+        }
+      ]
+    }
+  }
+}
+```
+
+### Step 2: Add middleware in the default app
+
+```ts
+// middleware.ts
+import type { NextRequest } from 'next/server';
+import { runMicrofrontendsMiddleware } from '@vercel/microfrontends/next/middleware';
+
+export async function middleware(request: NextRequest) {
+  const response = await runMicrofrontendsMiddleware({
+    request,
+    flagValues: {
+      'name-of-feature-flag': async () => {
+        // Return true to route to the microfrontend, false to keep on default app
+        return true;
+      },
+    },
+  });
+  if (response) return response;
+}
+
+export const config = {
+  matcher: [
+    '/.well-known/vercel/microfrontends/client-config',
+    '/flagged-path',
+  ],
+};
+```
+
+**Key points:**
+- The middleware matcher **must** include `/.well-known/vercel/microfrontends/client-config` (used for prefetch optimizations on flagged paths)
+- All flagged paths must be listed in the matcher
+- Compatible with the [Flags SDK](https://flags-sdk.dev) or any custom implementation
+- If using the Flags SDK, share the same `FLAGS_SECRET` across all microfrontends in the group
+- Any `async () => boolean` function works as a flag implementation
+
+## Domain Routing Rules
+
+### Production domains
+
+Always route to each project's current production deployment.
+
+### Custom environment domains
+
+Route to custom environments with the same name, or fallback per the fallback environment configuration.
+
+### Branch URLs
+
+Route to the latest deployment for the project on the branch. Fallback if no deployment exists.
+
+### Deployment URLs
+
+Fixed to point-in-time: routes to deployments created for the same commit, or previous commits from the branch.
+
+## Identifying Which Microfrontend Serves a Path
+
+**Dashboard:** Go to the default app project → Deployment → Deployment Summary → Microfrontends accordion.
+
+**Vercel Toolbar:** Open toolbar on any page → Microfrontends Panel → Directory.

--- a/.agents/skills/vercel-microfrontends/references/security.md
+++ b/.agents/skills/vercel-microfrontends/references/security.md
@@ -1,0 +1,64 @@
+# Managing Microfrontends Security
+
+> Source: [Vercel Docs — Managing microfrontends security](https://vercel.com/docs/microfrontends/managing-microfrontends/security)
+
+Understand how and where you manage [Deployment Protection](https://vercel.com/docs/deployment-protection) and [Vercel Firewall](https://vercel.com/docs/vercel-firewall) for each microfrontend application.
+
+- [Deployment Protection and microfrontends](#deployment-protection-and-microfrontends)
+- [Vercel Firewall and microfrontends](#vercel-firewall-and-microfrontends)
+
+## Deployment Protection and microfrontends
+
+Because each URL is protected by the [Deployment Protection](https://vercel.com/docs/security/deployment-protection) settings of the project it belongs to, the deployment protection for the microfrontend experience as a whole is determined by the **default application**.
+
+For requests to a microfrontend host (a domain belonging to the microfrontend default application):
+
+- Requests are **only** verified by the [Deployment Protection](https://vercel.com/docs/security/deployment-protection) settings for the project of your **default application**
+
+For requests directly to a child application (a domain belonging to a child microfrontend):
+
+- Requests are **only** verified by the [Deployment Protection](https://vercel.com/docs/security/deployment-protection) settings for the project of the **child application**
+
+This applies to all [protection methods](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments) and [bypass methods](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection), including:
+
+- [Vercel Authentication](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/vercel-authentication)
+- [Password Protection](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/password-protection)
+- [Trusted IPs](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips)
+- [Shareable Links](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/sharable-links)
+- [Protection Bypass for Automation](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation)
+- [Deployment Protection Exceptions](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/deployment-protection-exceptions)
+- [OPTIONS Allowlist](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/options-allowlist)
+
+### Managing Deployment Protection for your microfrontend
+
+Use the [Deployment Protection](https://vercel.com/docs/security/deployment-protection) settings for the project of the default application to control access to the microfrontend.
+
+Recommended configuration:
+
+- **Default app**: Use [Standard Protection](https://vercel.com/docs/security/deployment-protection) so that end users can access the microfrontend through the default app's URL.
+- **Child apps**: Enable [protection for all deployments](https://vercel.com/docs/security/deployment-protection) so that child apps are not directly accessible. Since child app content is served through the default app's URL, child apps can only be accessed via the URL of the default project.
+
+This works because Vercel handles routing to child apps within a single request at the network layer — as explained in [Path Routing](https://vercel.com/docs/microfrontends/path-routing) — it is not a rewrite that would result in a separate request to the child app's URL. Deployment protection on the child app therefore applies only when the child app's URL is accessed directly.
+
+## Vercel Firewall and microfrontends
+
+- The [Platform-wide firewall](https://vercel.com/docs/vercel-firewall#platform-wide-firewall) is applied to all requests.
+- The customizable [Web Application Firewall (WAF)](https://vercel.com/docs/vercel-firewall/vercel-waf) from the default application and the corresponding child application is applied for a request.
+
+### Vercel WAF and microfrontends
+
+For requests to a microfrontend host (a domain belonging to the microfrontend default application):
+
+- All requests are verified by the [Vercel WAF](https://vercel.com/docs/vercel-firewall/vercel-waf) for the project of your default application
+- Requests to child applications are **additionally** verified by the [Vercel WAF](https://vercel.com/docs/vercel-firewall/vercel-waf) for their project
+
+For requests directly to a child application (a domain belonging to a child microfrontend):
+
+- Requests are **only** verified by the [Vercel WAF](https://vercel.com/docs/vercel-firewall/vercel-waf) for the project of the child application.
+
+This applies for the entire [Vercel WAF](https://vercel.com/docs/vercel-firewall/vercel-waf), including [Custom Rules](https://vercel.com/docs/vercel-firewall/vercel-waf/custom-rules), [IP Blocking](https://vercel.com/docs/vercel-firewall/vercel-waf/ip-blocking), [WAF Managed Rulesets](https://vercel.com/docs/vercel-firewall/vercel-waf/managed-rulesets), and [Attack Challenge Mode](https://vercel.com/docs/vercel-firewall/attack-challenge-mode).
+
+### Managing the Vercel WAF for your microfrontend
+
+- To set a WAF rule that applies to all requests to a microfrontend, use the [Vercel WAF](https://vercel.com/docs/vercel-firewall/vercel-waf) for your default application.
+- To set a WAF rule that applies **only** to requests to paths of a child application, use the [Vercel WAF](https://vercel.com/docs/vercel-firewall/vercel-waf) for the child project.

--- a/.agents/skills/vercel-microfrontends/references/troubleshooting.md
+++ b/.agents/skills/vercel-microfrontends/references/troubleshooting.md
@@ -1,0 +1,217 @@
+# Testing & Troubleshooting Reference
+
+## Table of Contents
+
+- [Testing Utilities](#testing-utilities)
+  - [validateMiddlewareConfig](#validatemiddlewareconfig)
+  - [validateMiddlewareOnFlaggedPaths](#validatemiddlewareonflaggedpaths)
+  - [validateRouting](#validaterouting)
+- [Debug Headers](#debug-headers)
+- [Debug Routing Locally](#debug-routing-locally)
+- [Observability & Tracing](#observability--tracing)
+- [Common Issues](#common-issues)
+
+## Testing Utilities
+
+The `@vercel/microfrontends` package includes test utilities imported from `@vercel/microfrontends/next/testing`. All utilities throw exceptions on failure, so they work with any test framework.
+
+### validateMiddlewareConfig
+
+Validates that Next.js middleware is configured correctly for microfrontends. Run only on the **default application**.
+
+Checks:
+
+- Middleware matches `/.well-known/vercel/microfrontends/client-config`
+- Middleware does **not** match paths routed to child microfrontends (those requests never reach the default app's middleware)
+- Middleware **does** match all flagged paths
+
+```ts
+// tests/middleware.test.ts
+/* @jest-environment node */
+import { validateMiddlewareConfig } from "@vercel/microfrontends/next/testing";
+import { config } from "../middleware";
+
+describe("middleware", () => {
+  test("matches microfrontends paths", () => {
+    expect(() =>
+      validateMiddlewareConfig(config, "./microfrontends.json"),
+    ).not.toThrow();
+  });
+});
+```
+
+**Signature:**
+
+```ts
+function validateMiddlewareConfig(
+  middlewareConfig: MiddlewareConfig,
+  microfrontendConfigOrPath: string | MicrofrontendConfigIsomorphic,
+  extraProductionMatches?: string[],
+): void;
+```
+
+- `middlewareConfig`: The exported `config` from your `middleware.ts`
+- `microfrontendConfigOrPath`: Path to `microfrontends.json` or a parsed config object
+- `extraProductionMatches`: Optional paths that middleware intentionally matches despite being child app paths
+
+### validateMiddlewareOnFlaggedPaths
+
+Validates that middleware correctly rewrites flagged paths to the right microfrontend. **All flags must be enabled** before calling this function.
+
+```ts
+// tests/middleware.test.ts
+/* @jest-environment node */
+import { validateMiddlewareOnFlaggedPaths } from "@vercel/microfrontends/next/testing";
+import { middleware } from "../middleware";
+
+// Enable all flags before testing.
+// This mock is specific to the Flags SDK; adapt if using a custom flag implementation.
+jest.mock("flags/next", () => ({
+  flag: jest.fn().mockReturnValue(jest.fn().mockResolvedValue(true)),
+}));
+
+describe("middleware", () => {
+  test("rewrites for flagged paths", async () => {
+    await expect(
+      validateMiddlewareOnFlaggedPaths("./microfrontends.json", middleware),
+    ).resolves.not.toThrow();
+  });
+});
+```
+
+**Signature:**
+
+```ts
+async function validateMiddlewareOnFlaggedPaths(
+  microfrontendConfigOrPath: string | MicrofrontendConfigIsomorphic,
+  middleware: (
+    request: NextRequest,
+    event: NextFetchEvent,
+  ) => Promise<Response | undefined>,
+): Promise<void>;
+```
+
+### validateRouting
+
+Validates that specific paths route to the correct microfrontend application. Run only on the **default application** where `microfrontends.json` is defined.
+
+```ts
+// tests/microfrontends.test.ts
+import { validateRouting } from "@vercel/microfrontends/next/testing";
+
+describe("microfrontends", () => {
+  test("routing", () => {
+    expect(() => {
+      validateRouting("./microfrontends.json", {
+        marketing: ["/", "/products"],
+        docs: ["/docs", "/docs/api"],
+        dashboard: [
+          "/dashboard",
+          { path: "/new-dashboard", flag: "enable-new-dashboard" },
+        ],
+      });
+    }).not.toThrow();
+  });
+});
+```
+
+**Signature:**
+
+```ts
+function validateRouting(
+  microfrontendConfigOrPath: string | MicrofrontendConfigIsomorphic,
+  routesToTest: Record<string, (string | { path: string; flag: string })[]>,
+): void;
+```
+
+The `routesToTest` maps application names to arrays of paths. Each path can be:
+
+- A string: `'/docs'` — asserts this path routes to the named app
+- An object: `{ path: '/new-docs', flag: 'my-flag' }` — asserts this path routes to the named app when the flag is enabled
+
+## Debug Headers
+
+Enable debug headers to inspect routing decisions on deployed environments.
+
+### Enabling
+
+- Use the **Vercel Toolbar** → enable Routing Debug Mode, **or**
+- Set browser cookie `VERCEL_MFE_DEBUG=1`
+
+### Response headers
+
+| Header                                   | Description                                                 |
+| ---------------------------------------- | ----------------------------------------------------------- |
+| `x-vercel-mfe-app`                       | Microfrontend project that handled the request              |
+| `x-vercel-mfe-target-deployment-id`      | Deployment ID that handled the request                      |
+| `x-vercel-mfe-default-app-deployment-id` | Default app deployment ID (source of `microfrontends.json`) |
+| `x-vercel-mfe-zone-from-middleware`      | For flagged paths: which microfrontend middleware selected  |
+| `x-vercel-mfe-matched-path`              | Path pattern from `microfrontends.json` that matched        |
+| `x-vercel-mfe-response-reason`           | Internal reason for the routing decision                    |
+
+## Debug Routing Locally
+
+Enable debug logging for the local proxy:
+
+1. Set `MFE_DEBUG=1` environment variable, **or**
+2. Pass `debug: true` to `withMicrofrontends`:
+
+```ts
+export default withMicrofrontends(nextConfig, { debug: true });
+```
+
+The proxy logs show:
+
+- Which path matched which routing rule
+- Whether the request went to a local app or fallback
+- Environment variable and rewrite changes
+
+## Observability & Tracing
+
+### Observability dashboard
+
+Microfrontend routing data appears in the **Observability** tab under the CDN section → Microfrontends.
+
+### Session tracing
+
+Routing is captured in [Session Tracing](https://vercel.com/docs/tracing/session-tracing). The Microfrontends span includes:
+
+| Attribute                              | Description                                          |
+| -------------------------------------- | ---------------------------------------------------- |
+| `vercel.mfe.app`                       | Microfrontend that handled the request               |
+| `vercel.mfe.target_deployment_id`      | Target deployment ID                                 |
+| `vercel.mfe.default_app_deployment_id` | Default app deployment ID                            |
+| `vercel.mfe.app_from_middleware`       | Microfrontend selected by middleware (flagged paths) |
+| `vercel.mfe.matched_path`              | Matched path pattern                                 |
+
+## Common Issues
+
+### Microfrontends aren't working in local development
+
+1. Enable debug logging (`MFE_DEBUG=1`) to see routing decisions
+2. Verify the proxy is running and you're accessing the proxy URL (not the app's direct port)
+3. Check that `--local-apps` includes the correct app name
+4. Verify `microfrontends.json` is accessible (auto-detected in monorepos, needs manual config in polyrepos)
+
+### Requests not routed to the correct microfrontend in production
+
+1. Verify the path is covered by the routing config using the [Deployment Summary](https://vercel.com/docs/deployments#resources-tab-and-deployment-summary) or Vercel Toolbar
+2. Enable [debug headers](#debug-headers) and inspect `x-vercel-mfe-matched-path` and `x-vercel-mfe-app`
+3. Check [session traces](#session-tracing) for detailed routing information
+
+### Middleware not running for flagged paths
+
+- Ensure flagged paths are listed in the middleware `matcher` config
+- Verify `/.well-known/vercel/microfrontends/client-config` is in the matcher
+- Use `validateMiddlewareConfig` and `validateMiddlewareOnFlaggedPaths` tests to catch misconfigurations
+
+### Asset 404 errors
+
+- Verify the asset prefix is correctly configured and routed in `microfrontends.json`
+- For Next.js `public/` directory files, move them to a subdirectory matching the asset prefix
+- Check that `withMicrofrontends` (or the Vite plugin) is applied to the framework config
+
+### Deployment protection blocking fallbacks locally
+
+- The default app's `VERCEL_AUTOMATION_BYPASS_SECRET` is used to bypass protection on child projects — ensure that secret is also added as a [Protection Bypass for Automation](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation) secret in each protected child project
+- Add `VERCEL_AUTOMATION_BYPASS_SECRET=<secret>` to the default app's local environment file (e.g. `.env.local`)

--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/history/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/history/page.tsx
@@ -1,7 +1,7 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { portableTextToMarkdown } from '@ykzts/portable-text-utils'
 import type { Metadata } from 'next'
 import { draftMode } from 'next/headers'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import DateDisplay from '@/components/date-display'
 import LinkButton from '@/components/link-button'

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -1,5 +1,9 @@
 import './globals.css'
 import { Analytics } from '@vercel/analytics/next'
+import {
+  PrefetchCrossZoneLinks,
+  PrefetchCrossZoneLinksProvider
+} from '@vercel/microfrontends/next/client'
 import Header from '@ykzts/layout/components/header'
 import SiteFooter from '@ykzts/layout/components/site-footer'
 import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
@@ -89,15 +93,18 @@ export default function RootLayout({
           disableTransitionOnChange
           enableSystem
         >
-          <Suspense fallback={null}>
-            <DraftModeBanner />
-          </Suspense>
-          <Header
-            extra={<SearchForm className="hidden md:block md:w-48 lg:w-64" />}
-          />
-          {children}
-          <SiteFooter />
-          <Analytics />
+          <PrefetchCrossZoneLinksProvider>
+            <Suspense fallback={null}>
+              <DraftModeBanner />
+            </Suspense>
+            <Header
+              extra={<SearchForm className="hidden md:block md:w-48 lg:w-64" />}
+            />
+            {children}
+            <SiteFooter />
+            <Analytics />
+            <PrefetchCrossZoneLinks />
+          </PrefetchCrossZoneLinksProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/blog/app/not-found.tsx
+++ b/apps/blog/app/not-found.tsx
@@ -1,5 +1,5 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import type { Metadata } from 'next'
-import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: '404 Not Found'

--- a/apps/blog/components/article-header.tsx
+++ b/apps/blog/components/article-header.tsx
@@ -1,5 +1,5 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import type { Route } from 'next'
-import Link from 'next/link'
 import DateDisplay from './date-display'
 import TagList from './tag-list'
 

--- a/apps/blog/components/link-button.tsx
+++ b/apps/blog/components/link-button.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { Link } from '@vercel/microfrontends/next/client'
 import { Button } from '@ykzts/ui/components/button'
-import Link from 'next/link'
 import type { ComponentProps } from 'react'
 
 type LinkButtonProps = Omit<ComponentProps<typeof Button>, 'render'> &
@@ -16,9 +16,5 @@ export default function LinkButton({
   href,
   ...props
 }: LinkButtonProps) {
-  return (
-    <Button render={<Link href={href} />} {...props}>
-      {children}
-    </Button>
-  )
+  return <Button render={<Link href={href}>{children}</Link>} {...props} />
 }

--- a/apps/blog/components/link.tsx
+++ b/apps/blog/components/link.tsx
@@ -1,4 +1,4 @@
-import NextLink from 'next/link'
+import { Link as NextLink } from '@vercel/microfrontends/next/client'
 import type { ComponentProps } from 'react'
 
 export default function Link({
@@ -31,7 +31,6 @@ export default function Link({
   }
 
   return (
-    // @ts-expect-error - href is a valid string but Next.js Link expects a specific type
     <NextLink href={href} {...props}>
       {children}
     </NextLink>

--- a/apps/blog/components/post-card.tsx
+++ b/apps/blog/components/post-card.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { extractFirstParagraph } from '@ykzts/portable-text-utils'
 import { Badge } from '@ykzts/ui/components/badge'
 import {
@@ -8,7 +9,6 @@ import {
   CardHeader,
   CardTitle
 } from '@ykzts/ui/components/card'
-import Link from 'next/link'
 import { getPostUrl } from '@/lib/blog-urls'
 import type { PortableTextValue } from '@/lib/portable-text'
 import DateDisplay from './date-display'

--- a/apps/blog/components/search-results.tsx
+++ b/apps/blog/components/search-results.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { extractFirstParagraph } from '@ykzts/portable-text-utils'
 import {
   Card,
@@ -7,7 +8,6 @@ import {
   CardHeader,
   CardTitle
 } from '@ykzts/ui/components/card'
-import Link from 'next/link'
 import { getPostUrl } from '@/lib/blog-urls'
 import type { PortableTextValue } from '@/lib/portable-text'
 import DateDisplay from './date-display'

--- a/apps/blog/components/similar-posts.tsx
+++ b/apps/blog/components/similar-posts.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { extractFirstParagraph } from '@ykzts/portable-text-utils'
 import {
   Card,
@@ -7,7 +8,6 @@ import {
   CardHeader,
   CardTitle
 } from '@ykzts/ui/components/card'
-import Link from 'next/link'
 import { getPostUrl } from '@/lib/blog-urls'
 import type { PortableTextValue } from '@/lib/portable-text'
 import DateDisplay from './date-display'

--- a/apps/blog/components/tag-list.tsx
+++ b/apps/blog/components/tag-list.tsx
@@ -1,6 +1,6 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { Badge } from '@ykzts/ui/components/badge'
 import type { Route } from 'next'
-import Link from 'next/link'
 
 type TagListProps = {
   tags: string[]

--- a/apps/blog/vitest.setup.ts
+++ b/apps/blog/vitest.setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom/vitest'
+import React from 'react'
+import { vi } from 'vitest'
+
+vi.mock('@vercel/microfrontends/next/client', () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode
+    href: string
+    [key: string]: unknown
+  }) => React.createElement('a', { href, ...props }, children)
+}))

--- a/apps/portfolio/app/(docs)/layout.tsx
+++ b/apps/portfolio/app/(docs)/layout.tsx
@@ -1,5 +1,5 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { ArrowLeft } from 'lucide-react'
-import Link from 'next/link'
 
 export default function DocsLayout({ children }: LayoutProps<'/'>) {
   return (

--- a/apps/portfolio/app/_components/contact-form.tsx
+++ b/apps/portfolio/app/_components/contact-form.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { Turnstile } from '@marsidev/react-turnstile'
+import { Link } from '@vercel/microfrontends/next/client'
 import { Button } from '@ykzts/ui/components/button'
 import { Checkbox } from '@ykzts/ui/components/checkbox'
 import { Field, FieldError, FieldLabel } from '@ykzts/ui/components/field'
 import { Input } from '@ykzts/ui/components/input'
 import { Textarea } from '@ykzts/ui/components/textarea'
-import Link from 'next/link'
 import { useTheme } from 'next-themes'
 import { useActionState, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { getPosts } from '@ykzts/supabase/queries'
 import { cacheLife } from 'next/cache'
 import { Suspense } from 'react'
@@ -88,9 +89,9 @@ async function RecentPostsImpl() {
               key={post.id}
             >
               <h3 className="mb-2 font-semibold text-card-foreground text-lg">
-                <a className="hover:text-primary hover:underline" href={url}>
+                <Link className="hover:text-primary hover:underline" href={url}>
                   {post.title}
-                </a>
+                </Link>
               </h3>
               {post.excerpt && (
                 <p className="mb-3 line-clamp-2 text-muted-foreground text-sm leading-relaxed">
@@ -129,12 +130,12 @@ async function RecentPostsImpl() {
         })}
       </div>
       <div className="mt-8 text-center">
-        <a
+        <Link
           className="inline-flex items-center rounded-lg border border-border bg-card px-6 py-3 font-medium text-card-foreground transition-all duration-300 hover:border-primary/50 hover:shadow-md"
           href="/blog"
         >
           ブログをすべて見る
-        </a>
+        </Link>
       </div>
     </section>
   )

--- a/apps/portfolio/app/layout.tsx
+++ b/apps/portfolio/app/layout.tsx
@@ -1,5 +1,9 @@
 import './globals.css'
 import { Analytics } from '@vercel/analytics/react'
+import {
+  PrefetchCrossZoneLinks,
+  PrefetchCrossZoneLinksProvider
+} from '@vercel/microfrontends/next/client'
 import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
 import { getProfile } from '@ykzts/supabase/queries'
 import { Toaster } from '@ykzts/ui/components/sonner'
@@ -82,20 +86,23 @@ export default function RootLayout({ children, modal }: LayoutProps<'/'>) {
           disableTransitionOnChange
           enableSystem
         >
-          <a
-            className="absolute -top-20 left-2 z-1000 rounded bg-primary px-4 py-2 text-primary-foreground no-underline transition-[top] duration-300 focus-visible:top-2"
-            href="#content"
-          >
-            メインコンテンツにスキップ
-          </a>
+          <PrefetchCrossZoneLinksProvider>
+            <a
+              className="absolute -top-20 left-2 z-1000 rounded bg-primary px-4 py-2 text-primary-foreground no-underline transition-[top] duration-300 focus-visible:top-2"
+              href="#content"
+            >
+              メインコンテンツにスキップ
+            </a>
 
-          <SVGSymbols />
+            <SVGSymbols />
 
-          {children}
-          {modal}
+            {children}
+            {modal}
 
-          <Toaster />
-          <Analytics />
+            <Toaster />
+            <Analytics />
+            <PrefetchCrossZoneLinks />
+          </PrefetchCrossZoneLinksProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/portfolio/components/link.tsx
+++ b/apps/portfolio/components/link.tsx
@@ -1,9 +1,9 @@
+import { Link as NextLink } from '@vercel/microfrontends/next/client'
 import type { ComponentProps } from 'react'
 
 export default function Link({
   children,
   href,
-  ref,
   rel,
   target,
   ...props
@@ -17,15 +17,22 @@ export default function Link({
     relList.add('noopener')
   }
 
+  if (isExternal || !href) {
+    return (
+      <a
+        href={href}
+        rel={relList.size > 0 ? [...relList].join(' ') : undefined}
+        target={target ?? (isExternal ? '_blank' : undefined)}
+        {...props}
+      >
+        {children}
+      </a>
+    )
+  }
+
   return (
-    <a
-      href={href}
-      ref={ref}
-      rel={relList.size > 0 ? [...relList].join(' ') : undefined}
-      target={target ?? (isExternal ? '_blank' : undefined)}
-      {...props}
-    >
+    <NextLink href={href} {...props}>
       {children}
-    </a>
+    </NextLink>
   )
 }

--- a/apps/portfolio/vitest.setup.ts
+++ b/apps/portfolio/vitest.setup.ts
@@ -29,9 +29,9 @@ vi.mock('next/image', () => ({
   }) => React.createElement('img', { alt, src, ...props })
 }))
 
-// Mock Next.js Link component
-vi.mock('next/link', () => ({
-  default: ({
+// Mock microfrontends Link component
+vi.mock('@vercel/microfrontends/next/client', () => ({
+  Link: ({
     children,
     href,
     ...props

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -19,6 +19,7 @@
     "test": "vitest --run"
   },
   "dependencies": {
+    "@vercel/microfrontends": "2.3.4",
     "@ykzts/site-config": "workspace:*",
     "@ykzts/supabase": "workspace:*",
     "@ykzts/ui": "workspace:*",

--- a/packages/layout/src/components/header.tsx
+++ b/packages/layout/src/components/header.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@vercel/microfrontends/next/client'
 import { getSiteName } from '@ykzts/site-config'
 import type { ReactNode } from 'react'
 import NavigationWrapper from './navigation-wrapper'
@@ -12,13 +13,13 @@ export default function Header({ extra }: Props) {
   return (
     <header className="sticky top-0 z-10 border-border border-b bg-background/90 px-6 backdrop-blur-sm md:px-12 lg:px-24">
       <div className="mx-auto flex h-14 max-w-4xl items-center justify-between">
-        <a
+        <Link
           aria-label={siteName}
           className="font-semibold text-foreground text-lg"
           href="/"
         >
           {siteName}
-        </a>
+        </Link>
         <div className="flex items-center gap-2">
           {extra}
           <NavigationWrapper />

--- a/packages/layout/src/components/navigation.tsx
+++ b/packages/layout/src/components/navigation.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Link } from '@vercel/microfrontends/next/client'
 import { Button } from '@ykzts/ui/components/button'
 import {
   NavigationMenu,
@@ -108,26 +109,26 @@ export default function Navigation({ actions, navItems }: Props) {
                   </summary>
                   <div className="mt-1 ml-4 flex flex-col gap-1">
                     {item.children.map((child) => (
-                      <a
+                      <Link
                         className="rounded-md px-4 py-2 text-base text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
                         href={child.href}
                         key={child.href}
                         onClick={() => setOpen(false)}
                       >
                         {child.label}
-                      </a>
+                      </Link>
                     ))}
                   </div>
                 </details>
               ) : (
-                <a
+                <Link
                   className="rounded-md px-4 py-3 font-medium text-foreground text-lg transition-colors hover:bg-accent hover:text-accent-foreground"
                   href={item.href}
                   key={item.href}
                   onClick={() => setOpen(false)}
                 >
                   {item.label}
-                </a>
+                </Link>
               )
             )}
           </nav>

--- a/packages/layout/vitest.setup.ts
+++ b/packages/layout/vitest.setup.ts
@@ -27,8 +27,8 @@ vi.mock('next/image', () => ({
   }) => React.createElement('img', { alt, src, ...props })
 }))
 
-vi.mock('next/link', () => ({
-  default: ({
+vi.mock('@vercel/microfrontends/next/client', () => ({
+  Link: ({
     children,
     href,
     ...props

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,6 +563,9 @@ importers:
 
   packages/layout:
     dependencies:
+      '@vercel/microfrontends':
+        specifier: 2.3.4
+        version: 2.3.4(@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.8.3))
       '@ykzts/site-config':
         specifier: workspace:*
         version: link:../site-config

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -30,6 +30,12 @@
       "sourceType": "github",
       "skillPath": "skills/composition-patterns/SKILL.md",
       "computedHash": "575757e3e25761c8c562d6e395d29f0b76c98b1273c0bd72d88e6ab1bc9c7d42"
+    },
+    "vercel-microfrontends": {
+      "source": "vercel/microfrontends",
+      "sourceType": "github",
+      "skillPath": "skills/vercel-microfrontends/SKILL.md",
+      "computedHash": "cabdceabe3985a640fb5b5569aae0fdab7d0bcb2d077197ad43e485c1b05da07"
     }
   }
 }


### PR DESCRIPTION
This pull request introduces a new agent skill for working with microfrontends on Vercel. It adds comprehensive documentation and reference materials to help users build, configure, and deploy microfrontends, including detailed guides for configuration, local development, and troubleshooting. The documentation covers both high-level concepts and in-depth reference material, with clear instructions for integrating with various frameworks and managing complex setups.

The most important changes include:

**Skill Introduction and Metadata**
- Added the new `vercel-microfrontends` skill, including a high-level overview, core concepts, supported frameworks, and when to use the skill in `SKILL.md`.
- Created a `metadata.json` file describing the skill’s version, organization, abstract, and links to relevant documentation and references.
- Added a top-level `README.md` summarizing the skill’s structure, installation instructions, and links to official docs and npm.

**Reference Documentation**
- Added `references/configuration.md` with detailed explanations of the `microfrontends.json` schema, required fields, naming conventions, framework integration, and example configurations.
- Added `references/local-development.md`, providing a thorough guide to setting up local development environments, including proxy setup, monorepo/polyrepo instructions, port configuration, and handling protected deployments.