### PR TITLE
feat(blog): introduce markdown

### DIFF
--- a/apps/blog-legacy/redirects.test.ts
+++ b/apps/blog-legacy/redirects.test.ts
@@ -28,7 +28,7 @@ describe('createLegacyRedirects', () => {
     const redirects = createLegacyRedirects('https://example.com/')
 
     expect(redirects[1]).toEqual({
-      destination: 'https://example.com/blog/atom.xml',
+      destination: 'https://example.com/blog.atom',
       source: '/(feed/?|index.xml|rss)',
       statusCode: 301
     })

--- a/apps/blog-legacy/redirects.ts
+++ b/apps/blog-legacy/redirects.ts
@@ -2,7 +2,7 @@ export type LegacyRedirectTuple = [source: string, destination: string]
 
 export const legacyRedirects: LegacyRedirectTuple[] = [
   ['/([Aa]uthor|about)', '/'],
-  ['/(feed/?|index.xml|rss)', '/blog/atom.xml'],
+  ['/(feed/?|index.xml|rss)', '/blog.atom'],
   ['/post/20308520977', '/blog/2012/04/01/custom-http-header-on-nginx'],
   ['/post/25108537330', '/blog/2012/06/14/nodex-xmlhttprequest'],
   ['/post/25378068289', '/blog/2012/06/18/xmlhttprequest-response-type'],

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -13,7 +13,7 @@ This application powers the blog section at [ykzts.com/blog](https://ykzts.com/b
 - **Supabase Integration**: PostgreSQL database for article management and storage
 - **AI-Powered Similar Posts**: Embedding-based similar article recommendations via Vercel AI SDK
 - **Vercel Analytics**: Performance monitoring and user analytics
-- **Atom Feed**: Syndication feed generated at `/blog/atom.xml`
+- **Atom Feed**: Syndication feed generated at `/blog.atom`
 - **Sitemap**: Auto-generated sitemap at `/blog/sitemap.xml`
 - **Full-Text Search**: Article search powered by Supabase
 - **Draft Mode**: Preview unpublished posts via secure draft endpoints

--- a/apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.ts
+++ b/apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.ts
@@ -1,0 +1,57 @@
+import { portableTextToMarkdown } from '@ykzts/portable-text-utils'
+import type { NextRequest } from 'next/server'
+import { isPortableTextValue } from '@/lib/portable-text'
+import { getPostBySlug } from '@/lib/supabase/posts'
+
+export async function GET(
+  _request: NextRequest,
+  context: RouteContext<'/api/blog/markdown/[year]/[month]/[day]/[slug]'>
+) {
+  const { day, month, slug, year } = await context.params
+  const post = await getPostBySlug(slug)
+
+  if (!post?.published_at) {
+    return new Response('# Not Found\n', {
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+      status: 404
+    })
+  }
+
+  const publishedDate = new Date(post.published_at)
+  const publishedAt = publishedDate.getTime()
+
+  if (publishedAt > Date.now()) {
+    return new Response('# Not Found\n', {
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+      status: 404
+    })
+  }
+
+  const publishedYear = String(publishedDate.getUTCFullYear())
+  const publishedMonth = String(publishedDate.getUTCMonth() + 1).padStart(
+    2,
+    '0'
+  )
+  const publishedDay = String(publishedDate.getUTCDate()).padStart(2, '0')
+
+  if (
+    year !== publishedYear ||
+    month !== publishedMonth ||
+    day !== publishedDay ||
+    !isPortableTextValue(post.content)
+  ) {
+    return new Response('# Not Found\n', {
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+      status: 404
+    })
+  }
+
+  const body = portableTextToMarkdown(post.content, { headingOffset: 2 })
+
+  return new Response([`# ${post.title}`, `${body}\n`].join('\n\n'), {
+    headers: {
+      'Cache-Control': 'max-age=600, stale-while-revalidate=3600',
+      'Content-Type': 'text/markdown; charset=utf-8'
+    }
+  })
+}

--- a/apps/blog/app/api/blog/markdown/route.ts
+++ b/apps/blog/app/api/blog/markdown/route.ts
@@ -1,0 +1,62 @@
+import { portableTextToMarkdown } from '@ykzts/portable-text-utils'
+import { connection } from 'next/server'
+import { getPostUrl } from '@/lib/blog-urls'
+import { isPortableTextValue } from '@/lib/portable-text'
+import { getPosts } from '@/lib/supabase/posts'
+
+const textEncoder = new TextEncoder()
+
+function isAbailablePost(
+  post: Awaited<ReturnType<typeof getPosts>>[number],
+  { now }: { now: number }
+): boolean {
+  if (!post.published_at) return false
+
+  const publishedDate = new Date(post.published_at).getTime()
+
+  return publishedDate <= now
+}
+
+export async function GET(request: Request) {
+  await connection()
+
+  const now = Date.now()
+
+  const body = new ReadableStream({
+    cancel(controller) {
+      controller.close()
+    },
+    async start(controller) {
+      controller.enqueue(textEncoder.encode(`# Blog Posts\n\n`))
+
+      const posts = await getPosts()
+
+      for (const post of posts) {
+        if (!isAbailablePost(post, { now })) continue
+
+        const url = `${getPostUrl(post.slug, post.published_at)}.md`
+
+        controller.enqueue(textEncoder.encode(`## [${post.title}](${url})\n\n`))
+
+        const body = isPortableTextValue(post.content)
+          ? portableTextToMarkdown(post.content, { headingOffset: 3 })
+          : post.excerpt
+
+        controller.enqueue(textEncoder.encode(`${body}\n\n`))
+      }
+
+      controller.close()
+    }
+  })
+
+  request.signal.addEventListener('abort', () => {
+    body.cancel()
+  })
+
+  return new Response(body, {
+    headers: {
+      'Cache-Control': 'max-age=600, stale-while-revalidate=3600',
+      'Content-Type': 'text/markdown; charset=utf-8'
+    }
+  })
+}

--- a/apps/blog/app/blog.atom/route.ts
+++ b/apps/blog/app/blog.atom/route.ts
@@ -27,8 +27,18 @@ export async function GET() {
       }
     : undefined
 
+  const latestPostUpdatedAt =
+    posts.length > 0
+      ? posts.reduce((latest, post) => {
+          const postDate = new Date(post.version_date ?? post.published_at)
+          return postDate.getTime() > latest.getTime() ? postDate : latest
+        }, new Date(0))
+      : undefined
+
   const feedCopyright = profileName
-    ? `Copyright © ${new Date().getFullYear()} ${profileName}`
+    ? latestPostUpdatedAt
+      ? `Copyright © ${latestPostUpdatedAt.getFullYear()} ${profileName}`
+      : `Copyright © ${profileName}`
     : undefined
 
   const feed = new Feed({
@@ -37,11 +47,13 @@ export async function GET() {
     description: 'Blog',
     favicon: new URL('/favicon.ico', siteOrigin).toString(),
     feedLinks: {
-      atom: new URL('/blog/atom.xml', siteOrigin).toString()
+      atom: new URL('/blog.atom', siteOrigin).toString()
     },
+    generator: 'Next.js with feed package',
     id: baseUrl,
     link: baseUrl,
-    title: `Blog | ${getSiteName()}`
+    title: `Blog | ${getSiteName()}`,
+    updated: latestPostUpdatedAt
   })
 
   for (const post of posts) {
@@ -56,11 +68,11 @@ export async function GET() {
 
     feed.addItem({
       content: portableTextToHTML(post.content),
-      date: new Date(post.published_at),
+      date: post.version_date ? new Date(post.version_date) : publishedDate,
       description: post.excerpt || undefined,
       id: postUrl,
       link: postUrl,
-      published: new Date(post.published_at),
+      published: publishedDate,
       title: post.title || DEFAULT_POST_TITLE
     })
   }

--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
@@ -104,8 +104,15 @@ export async function generateMetadata({
 
   const authorName = post.profile.name
   const fediverseCreator = post.profile.fediverse_creator?.trim()
+  const url = getDateBasedUrl(slug, post.published_at)
 
   return {
+    alternates: {
+      canonical: url,
+      types: {
+        'text/markdown': `${url}.md`
+      }
+    },
     authors: [{ name: authorName }],
     description: post.excerpt || undefined,
     openGraph: {
@@ -116,7 +123,7 @@ export async function generateMetadata({
       tags: post.tags ?? undefined,
       title: post.title || DEFAULT_POST_TITLE,
       type: 'article',
-      url: getDateBasedUrl(slug, post.published_at)
+      url
     },
     other: {
       ...(fediverseCreator ? { 'fediverse:creator': fediverseCreator } : {})

--- a/apps/blog/app/blog/layout.tsx
+++ b/apps/blog/app/blog/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 export const metadata: Metadata = {
   alternates: {
     types: {
-      'application/atom+xml': '/blog/atom.xml'
+      'application/atom+xml': '/blog.atom'
     }
   }
 }

--- a/apps/blog/app/blog/page.tsx
+++ b/apps/blog/app/blog/page.tsx
@@ -23,6 +23,12 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 
   return {
+    alternates: {
+      canonical: '/blog',
+      types: {
+        'text/markdown': '/blog.md'
+      }
+    },
     description,
     openGraph: {
       description,

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -11,6 +11,25 @@ const nextConfig: NextConfig = {
   images: getSupabaseImageConfig(),
   reactCompiler: true,
   reactStrictMode: true,
+  redirects: async () => [
+    {
+      destination: '/blog.atom',
+      permanent: true,
+      source: '/blog/atom.xml'
+    }
+  ],
+  rewrites: async () => ({
+    beforeFiles: [
+      {
+        destination: '/api/blog/markdown',
+        source: '/blog.md'
+      },
+      {
+        destination: '/api/blog/markdown/:year/:month/:day/:slug',
+        source: '/blog/:year/:month/:day/:slug.md'
+      }
+    ]
+  }),
   typedRoutes: true
 }
 

--- a/apps/portfolio/microfrontends.json
+++ b/apps/portfolio/microfrontends.json
@@ -10,7 +10,13 @@
       "routing": [
         {
           "group": "blog",
-          "paths": ["/blog", "/blog/:path*", "/api/blog/:path*"]
+          "paths": [
+            "/blog",
+            "/blog.atom",
+            "/blog.md",
+            "/blog/:path*",
+            "/api/blog/:path*"
+          ]
         }
       ]
     },


### PR DESCRIPTION
This pull request introduces several improvements and changes to the blog application, focusing on simplifying feed URLs, adding Markdown endpoints for posts, and improving metadata and routing. The most significant updates are the migration of the Atom feed URL, new Markdown APIs for posts, and enhanced metadata and routing to support these changes.

**Feed and Redirect Updates:**
- Changed the Atom feed URL from `/blog/atom.xml` to `/blog.atom`, updated all references, and added a permanent redirect from the old URL to the new one. This includes updates in the `next.config.ts`, test cases, legacy redirects, and metadata. [[1]](diffhunk://#diff-fc822d0c4a2d925ddd1318600d6dccde5fbea49a47554351cbdbbed4379e9b2dR14-R32) [[2]](diffhunk://#diff-d1694c9143603ea09f443e0e55aea1b94592c319ff754caef428921448a3a62cL31-R31) [[3]](diffhunk://#diff-803ae756210978b2c7c1cd0622412ae228b41d9484821e5ccb363fa2709fcf6bL5-R5) [[4]](diffhunk://#diff-d199f7dbef88481beeea511e7d23b23d0d13a3e47289f32bfc00f8535e5310ffL7-R7) [[5]](diffhunk://#diff-393caa6788c731dc7656498b0646ca3d1a1382b113aecd4434ffcda4397e5495L40-R51)
- Renamed the Atom feed route file to match the new URL and updated feed metadata to use the latest post's year for copyright.

**New Markdown Endpoints:**
- Added a new API endpoint at `/api/blog/markdown` that streams a Markdown-formatted list of published blog posts, including titles and excerpts.
- Added a new API endpoint at `/api/blog/markdown/[year]/[month]/[day]/[slug]` to serve individual blog posts as Markdown, with validation for the correct date and slug. ([apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.tsR1-R46](diffhunk://#diff-e75705c4826d1c02217adda218a5ebfe2788abc5b7362aacbb7f81cf8154fc8eR1-R46))
- Configured rewrites so `/blog.md` and `/blog/:year/:month/:day/:slug.md` map to these new endpoints. [[1]](diffhunk://#diff-fc822d0c4a2d925ddd1318600d6dccde5fbea49a47554351cbdbbed4379e9b2dR14-R32) [[2]](diffhunk://#diff-7c7a0753407c6715d333f8a7daf082f571e67846f7ba855c7ce4fc9bf2abc864L13-R19)

**Metadata and SEO Improvements:**
- Enhanced page metadata to include canonical and alternate links for Markdown versions of posts, improving discoverability and SEO. ([apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsxR107-R115](diffhunk://#diff-24d5972ed4fd7e6150e5203aa3fbdd3e1b793e360425fbc92ef0351e5fa5d60bR107-R115), [apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsxL119-R126](diffhunk://#diff-24d5972ed4fd7e6150e5203aa3fbdd3e1b793e360425fbc92ef0351e5fa5d60bL119-R126))

**Feed Content Improvements:**
- Updated the Atom feed to use the latest post's version date for the copyright year.
- The feed now sets the generator and updated fields, and uses `version_date` for post dates if available. [[1]](diffhunk://#diff-393caa6788c731dc7656498b0646ca3d1a1382b113aecd4434ffcda4397e5495R30-R36) [[2]](diffhunk://#diff-393caa6788c731dc7656498b0646ca3d1a1382b113aecd4434ffcda4397e5495L40-R51) [[3]](diffhunk://#diff-393caa6788c731dc7656498b0646ca3d1a1382b113aecd4434ffcda4397e5495L59-R70)

**Documentation:**
- Updated the README to reflect the new Atom feed URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ブログ記事をMarkdown形式で取得できるようになりました。

* **Bug Fixes**
  * ブログフィードのURLを更新しました。
  * Atomフィード更新日時の計算ロジックを改善しました。

* **Documentation**
  * ブログドキュメントのフィード参照先を更新しました。

* **Chores**
  * ブログレイアウトのメタデータ参照先を更新しました。
  * ルーティング設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->