### PR TITLE
fix(blog): fix invalid `headingOffset`

### DIFF
--- a/apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.ts
+++ b/apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.ts
@@ -46,7 +46,7 @@ export async function GET(
     })
   }
 
-  const body = portableTextToMarkdown(post.content, { headingOffset: 2 })
+  const body = portableTextToMarkdown(post.content, { headingOffset: 0 })
 
   return new Response([`# ${post.title}`, `${body}\n`].join('\n\n'), {
     headers: {

--- a/apps/blog/app/api/blog/markdown/route.ts
+++ b/apps/blog/app/api/blog/markdown/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: Request) {
         controller.enqueue(textEncoder.encode(`## [${post.title}](${url})\n\n`))
 
         const body = isPortableTextValue(post.content)
-          ? portableTextToMarkdown(post.content, { headingOffset: 3 })
+          ? portableTextToMarkdown(post.content, { headingOffset: 1 })
           : post.excerpt
 
         controller.enqueue(textEncoder.encode(`${body}\n\n`))


### PR DESCRIPTION
This pull request adjusts the heading levels in the generated markdown output for blog posts by updating the `headingOffset` parameter passed to the `portableTextToMarkdown` function in two API routes.

Markdown formatting changes:

* In `apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.ts`, the `headingOffset` for markdown export is changed from 2 to 0, so headings in the markdown now match the original content's heading levels. ([apps/blog/app/api/blog/markdown/[year]/[month]/[day]/[slug]/route.tsL49-R49](diffhunk://#diff-e75705c4826d1c02217adda218a5ebfe2788abc5b7362aacbb7f81cf8154fc8eL49-R49))
* In `apps/blog/app/api/blog/markdown/route.ts`, the `headingOffset` is changed from 3 to 1, resulting in headings that are one level deeper than before in the exported markdown summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ブログ投稿のマークダウン出力における見出しレベルを調整しました。API経由でエクスポートされるマークダウンファイルの見出し階層（#、##など）の表示が更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->