### PR TITLE
fix(blog): resolve build-time warnings with cache components

### DIFF
--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -6,7 +6,7 @@ import {
 import Header from '@ykzts/layout/components/header'
 import SiteFooter from '@ykzts/layout/components/site-footer'
 import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
-import { getProfile } from '@ykzts/supabase/queries'
+import { getProfileOptional } from '@ykzts/supabase/queries'
 import { cn } from '@ykzts/ui/lib/utils'
 import type { Metadata, Viewport } from 'next'
 import { Inter, JetBrains_Mono, Noto_Sans_JP } from 'next/font/google'
@@ -19,8 +19,8 @@ import ThemeProvider from '@/components/theme-provider'
 const siteName = getSiteName()
 
 export async function generateMetadata(): Promise<Metadata> {
-  const profile = await getProfile()
-  const fediverseCreator = profile.fediverse_creator?.trim() || null
+  const profile = await getProfileOptional()
+  const fediverseCreator = profile?.fediverse_creator?.trim() || null
 
   return {
     metadataBase: getSiteOrigin(),

--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -1,5 +1,4 @@
 import './globals.css'
-import { Analytics } from '@vercel/analytics/next'
 import {
   PrefetchCrossZoneLinks,
   PrefetchCrossZoneLinksProvider
@@ -12,6 +11,7 @@ import { cn } from '@ykzts/ui/lib/utils'
 import type { Metadata, Viewport } from 'next'
 import { Inter, JetBrains_Mono, Noto_Sans_JP } from 'next/font/google'
 import { Suspense } from 'react'
+import AnalyticsClient from '@/components/analytics-client'
 import DraftModeBanner from '@/components/draft-mode-banner'
 import SearchForm from '@/components/search-form'
 import ThemeProvider from '@/components/theme-provider'
@@ -19,14 +19,8 @@ import ThemeProvider from '@/components/theme-provider'
 const siteName = getSiteName()
 
 export async function generateMetadata(): Promise<Metadata> {
-  let fediverseCreator: string | null = null
-
-  try {
-    const profile = await getProfile()
-    fediverseCreator = profile.fediverse_creator?.trim() || null
-  } catch (error) {
-    console.error('Failed to load profile for blog layout metadata:', error)
-  }
+  const profile = await getProfile()
+  const fediverseCreator = profile.fediverse_creator?.trim() || null
 
   return {
     metadataBase: getSiteOrigin(),
@@ -102,7 +96,7 @@ export default function RootLayout({
             />
             {children}
             <SiteFooter />
-            <Analytics />
+            <AnalyticsClient />
             <PrefetchCrossZoneLinks />
           </PrefetchCrossZoneLinksProvider>
         </ThemeProvider>

--- a/apps/blog/components/analytics-client.tsx
+++ b/apps/blog/components/analytics-client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { Analytics } from '@vercel/analytics/react'
+
+export default function AnalyticsClient() {
+  return <Analytics />
+}

--- a/packages/layout/src/components/navigation-wrapper.tsx
+++ b/packages/layout/src/components/navigation-wrapper.tsx
@@ -1,11 +1,14 @@
-import { getProfile, getWorks } from '@ykzts/supabase/queries'
+import { getProfileOptional, getWorksOptional } from '@ykzts/supabase/queries'
 import { Suspense } from 'react'
 import SiteNavigation from './site-navigation'
 
 async function NavigationImpl() {
-  const [profile, works] = await Promise.all([getProfile(), getWorks()])
+  const [profile, works] = await Promise.all([
+    getProfileOptional(),
+    getWorksOptional()
+  ])
 
-  const hasAbout = !!profile.about
+  const hasAbout = !!profile?.about
   const hasWorks = works.length > 0
 
   return <SiteNavigation hasAbout={hasAbout} hasWorks={hasWorks} />

--- a/packages/layout/src/components/navigation-wrapper.tsx
+++ b/packages/layout/src/components/navigation-wrapper.tsx
@@ -3,26 +3,10 @@ import { Suspense } from 'react'
 import SiteNavigation from './site-navigation'
 
 async function NavigationImpl() {
-  const [profileResult, worksResult] = await Promise.allSettled([
-    getProfile(),
-    getWorks()
-  ])
+  const [profile, works] = await Promise.all([getProfile(), getWorks()])
 
-  if (profileResult.status === 'rejected') {
-    console.error(
-      'Failed to load profile for navigation:',
-      profileResult.reason
-    )
-  }
-
-  if (worksResult.status === 'rejected') {
-    console.error('Failed to load works for navigation:', worksResult.reason)
-  }
-
-  const hasAbout =
-    profileResult.status === 'fulfilled' && !!profileResult.value.about
-  const hasWorks =
-    worksResult.status === 'fulfilled' && worksResult.value.length > 0
+  const hasAbout = !!profile.about
+  const hasWorks = works.length > 0
 
   return <SiteNavigation hasAbout={hasAbout} hasWorks={hasWorks} />
 }

--- a/packages/supabase/src/queries.ts
+++ b/packages/supabase/src/queries.ts
@@ -74,25 +74,68 @@ function normalizePage(page: number): number {
     : 1
 }
 
+function normalizeProfile(
+  profileData: {
+    about: unknown
+    key_visual: unknown
+    profile_technologies: unknown
+    social_links: unknown
+  } & Record<string, unknown>
+): Profile {
+  let aboutRaw = profileData.about
+
+  if (typeof aboutRaw === 'string') {
+    try {
+      aboutRaw = JSON.parse(aboutRaw)
+    } catch {
+      aboutRaw = null
+    }
+  }
+
+  const about = isPortableTextValue(aboutRaw) ? aboutRaw : null
+
+  const social_links = Array.isArray(profileData.social_links)
+    ? profileData.social_links
+    : []
+  const profile_technologies = Array.isArray(profileData.profile_technologies)
+    ? profileData.profile_technologies
+    : []
+  const key_visual = Array.isArray(profileData.key_visual)
+    ? (profileData.key_visual[0] ?? null)
+    : profileData.key_visual
+
+  return {
+    ...(profileData as Profile),
+    about,
+    key_visual,
+    profile_technologies,
+    social_links
+  }
+}
+
+function getSupabaseConfigError(): Error {
+  return new Error(
+    'Supabase is not properly configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.'
+  )
+}
+
 /**
- * Fetches the site publisher's profile.
+ * Shared profile fetch primitive used by both strict and tolerant query APIs.
  *
- * Unlike `getWorks` and `getPosts`, this function throws when Supabase is not
- * configured, because a missing profile is a critical error (no sensible
- * default exists). Callers that can tolerate failure should catch the error
- * themselves (e.g. `getProfile().catch(() => null)`).
+ * - `profile` contains normalized data when available.
+ * - `error` contains the root cause when the fetch cannot be satisfied.
  */
-export async function getProfile(): Promise<Profile> {
-  'use cache'
-
-  cacheTag('profile')
-
+async function fetchProfileData(): Promise<{
+  error: Error | null
+  profile: Profile | null
+}> {
   const supabase = createSupabaseClient()
 
   if (!supabase) {
-    throw new Error(
-      'Supabase is not properly configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.'
-    )
+    return {
+      error: getSupabaseConfigError(),
+      profile: null
+    }
   }
 
   const { data: profileData, error: profileError } = await supabase
@@ -119,59 +162,42 @@ export async function getProfile(): Promise<Profile> {
     .maybeSingle()
 
   if (profileError) {
-    throw new Error(`Failed to fetch profile: ${profileError.message}`)
-  }
-
-  if (!profileData) {
-    throw new Error('Profile not found')
-  }
-
-  let aboutRaw = profileData.about
-
-  if (typeof aboutRaw === 'string') {
-    try {
-      aboutRaw = JSON.parse(aboutRaw)
-    } catch {
-      aboutRaw = null
+    return {
+      error: new Error(`Failed to fetch profile: ${profileError.message}`),
+      profile: null
     }
   }
 
-  const about = isPortableTextValue(aboutRaw) ? aboutRaw : null
-
-  const social_links = Array.isArray(profileData.social_links)
-    ? profileData.social_links
-    : []
-  const profile_technologies = Array.isArray(profileData.profile_technologies)
-    ? profileData.profile_technologies
-    : []
-  const key_visual = Array.isArray(profileData.key_visual)
-    ? (profileData.key_visual[0] ?? null)
-    : profileData.key_visual
+  if (!profileData) {
+    return {
+      error: new Error('Profile not found'),
+      profile: null
+    }
+  }
 
   return {
-    ...profileData,
-    about,
-    key_visual,
-    profile_technologies,
-    social_links
+    error: null,
+    profile: normalizeProfile(profileData)
   }
 }
 
 /**
- * Fetches all works ordered by start date descending.
+ * Shared works fetch primitive used by both strict and tolerant query APIs.
  *
- * Returns an empty array when Supabase is not configured, so pages that list
- * works can still render without a profile dependency.
+ * - Returns an empty array when data is unavailable.
+ * - Returns `error` only for actual query failures.
  */
-export async function getWorks(): Promise<Work[]> {
-  'use cache'
-
-  cacheTag('works')
-
+async function fetchWorksData(): Promise<{
+  error: Error | null
+  works: Work[]
+}> {
   const supabase = createSupabaseClient()
 
   if (!supabase) {
-    return []
+    return {
+      error: null,
+      works: []
+    }
   }
 
   const { data, error } = await supabase
@@ -189,24 +215,105 @@ export async function getWorks(): Promise<Work[]> {
     .order('starts_at', { ascending: false })
 
   if (error) {
-    throw new Error(`Failed to fetch works: ${error.message}`)
+    return {
+      error: new Error(`Failed to fetch works: ${error.message}`),
+      works: []
+    }
   }
 
-  return data.map((work) => {
-    const work_urls = Array.isArray(work.work_urls)
-      ? [...work.work_urls].sort((a, b) => a.sort_order - b.sort_order)
-      : []
-    const work_technologies = Array.isArray(work.work_technologies)
-      ? work.work_technologies
-      : []
-
+  if (!data) {
     return {
-      ...work,
-      content: isPortableTextValue(work.content) ? work.content : null,
-      work_technologies,
-      work_urls
+      error: null,
+      works: []
     }
-  })
+  }
+
+  return {
+    error: null,
+    works: data.map((work) => {
+      const work_urls = Array.isArray(work.work_urls)
+        ? [...work.work_urls].sort((a, b) => a.sort_order - b.sort_order)
+        : []
+      const work_technologies = Array.isArray(work.work_technologies)
+        ? work.work_technologies
+        : []
+
+      return {
+        ...work,
+        content: isPortableTextValue(work.content) ? work.content : null,
+        work_technologies,
+        work_urls
+      }
+    })
+  }
+}
+
+/**
+ * Fetches profile data in a tolerant way for UI/metadata paths that should not
+ * fail hard when Supabase is unavailable.
+ *
+ * Returns `null` for missing configuration, query errors, and missing profile.
+ */
+export async function getProfileOptional(): Promise<Profile | null> {
+  const { profile } = await fetchProfileData()
+
+  return profile
+}
+
+/**
+ * Fetches works in a tolerant way for UI paths that should render even when
+ * Supabase is unavailable.
+ *
+ * Returns an empty array for missing configuration and query errors.
+ */
+export async function getWorksOptional(): Promise<Work[]> {
+  const { works } = await fetchWorksData()
+
+  return works
+}
+
+/**
+ * Fetches the site publisher's profile.
+ *
+ * This is the strict variant and throws when profile data cannot be obtained.
+ * Callers that can tolerate failure should use `getProfileOptional()`.
+ */
+export async function getProfile(): Promise<Profile> {
+  'use cache'
+
+  cacheTag('profile')
+
+  const { error, profile } = await fetchProfileData()
+
+  if (error) {
+    throw error
+  }
+
+  if (!profile) {
+    throw new Error('Profile not found')
+  }
+
+  return profile
+}
+
+/**
+ * Fetches all works ordered by start date descending.
+ *
+ * This is the strict variant and throws for query failures.
+ * Callers that can tolerate failure should use `getWorksOptional()`.
+ */
+export async function getWorks(): Promise<Work[]> {
+  'use cache'
+
+  cacheTag('works')
+
+  const { error, works } = await fetchWorksData()
+
+  if (error) {
+    throw error
+  }
+
+  return works
 }
 
 /**

--- a/packages/supabase/src/queries.ts
+++ b/packages/supabase/src/queries.ts
@@ -1,18 +1,26 @@
 import type { PortableTextBlock } from '@portabletext/types'
+import { createClient } from '@supabase/supabase-js'
 import { cacheTag } from 'next/cache'
-import { createBrowserClient } from './client'
+import type { Database } from './database.types.js'
 import type { Post, PostAuthor, PostSummary, Profile, Work } from './dto'
 
 const POSTS_PER_PAGE = 10
 
 function createSupabaseClient() {
-  if (
-    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  ) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
     return null
   }
-  return createBrowserClient()
+
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false
+    }
+  })
 }
 
 function isPortableTextValue(value: unknown): value is PortableTextBlock[] {


### PR DESCRIPTION
## Summary
- move analytics rendering in blog layout to a client wrapper component (`@vercel/analytics/react`)
- align navigation/profile loading flow with Next.js Cache Components behavior
- switch cached Supabase queries to a `@supabase/supabase-js` client configuration suitable for server-side cached access

## Validation
- `pnpm --filter @ykzts/blog build`
- `pnpm --filter @ykzts/admin build`
- `pnpm --filter @ykzts/memo build`
- `pnpm --filter @ykzts/portfolio build`
- `pnpm --filter @ykzts/blog-legacy build`

## Notes
- commit includes `Assisted-by: GitHub Copilot (GPT-5.3-Codex)` trailer as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * メタデータ生成時のエラーハンドリング処理を改善し、より堅牢になりました

* **Refactor**
  * Analytics機能の実装方法を最適化
  * プロファイルとコンテンツ取得ロジックを単純化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->