### PR TITLE
fix(workspace): stabilize monorepo typecheck workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,6 +33,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: pnpm install
       - run: pnpm typegen
+      - run: pnpm typecheck
       - run: pnpm exec biome ci --css-parse-tailwind-directives=true
       - run: pnpm test
       - run: pnpm validate

--- a/apps/admin/lib/__tests__/portable-text-utils.test.ts
+++ b/apps/admin/lib/__tests__/portable-text-utils.test.ts
@@ -336,7 +336,9 @@ describe('extractFirstParagraph', () => {
         }
       ]
 
-      const result = extractFirstParagraph(content)
+      const result = extractFirstParagraph(
+        content as unknown as Parameters<typeof extractFirstParagraph>[0]
+      )
       expect(result).toBe('Valid paragraph.')
     })
 
@@ -391,7 +393,9 @@ describe('extractFirstParagraph', () => {
         }
       ]
 
-      const result = extractFirstParagraph(content)
+      const result = extractFirstParagraph(
+        content as unknown as Parameters<typeof extractFirstParagraph>[0]
+      )
       expect(result).toBe('Valid paragraph.')
     })
   })

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -53,6 +53,7 @@
     "dev": "next dev --port 3001",
     "start": "next start",
     "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "next typegen"
   },
   "type": "module",

--- a/apps/blog-legacy/package.json
+++ b/apps/blog-legacy/package.json
@@ -36,6 +36,7 @@
     "dev": "next dev --port 3003",
     "start": "next start",
     "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "next typegen"
   },
   "type": "module",

--- a/apps/blog/additional.d.ts
+++ b/apps/blog/additional.d.ts
@@ -1,8 +1,5 @@
-/// <reference types="mdx" />
-
 // TODO(ykzts): Remove this shim once TS subpath type resolution for
 // @vercel/microfrontends/* and @vercel/analytics/react is stable in monorepo typecheck.
-
 declare module '@vercel/microfrontends/next/client' {
   export const Link: import('react').ComponentType<Record<string, unknown>>
   export const PrefetchCrossZoneLinks: import('react').ComponentType<Record<string, never>>
@@ -17,10 +14,4 @@ declare module '@vercel/microfrontends/next/config' {
 
 declare module '@vercel/analytics/react' {
   export const Analytics: import('react').ComponentType<Record<string, unknown>>
-}
-
-declare module '*.svg' {
-  const content: import('next/image').StaticImageData
-
-  export default content
 }

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -60,6 +60,7 @@
     "dev": "next dev --port $(microfrontends port)",
     "start": "next start",
     "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "next typegen"
   },
   "type": "module",

--- a/apps/memo/package.json
+++ b/apps/memo/package.json
@@ -41,6 +41,7 @@
     "build": "next build",
     "dev": "next dev --port 3003",
     "start": "next start",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "next typegen"
   },
   "type": "module",

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -72,6 +72,7 @@
     "start": "next start",
     "test": "vitest --run",
     "test:a11y": "playwright test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "next typegen"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lighthouse": "turbo run lighthouse",
     "test": "turbo run test",
     "test:a11y": "turbo run test:a11y",
+    "typecheck": "turbo run typecheck",
     "typegen": "turbo run typegen",
     "validate": "turbo run validate"
   },

--- a/packages/fediverse/package.json
+++ b/packages/fediverse/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "ipaddr.js": "2.4.0",

--- a/packages/fediverse/src/index.test.ts
+++ b/packages/fediverse/src/index.test.ts
@@ -1,9 +1,9 @@
 import * as dns from 'node:dns/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { extractFediverseHandleFromURL, verifyFediverseHandle } from './index'
+import { extractFediverseHandleFromURL, verifyFediverseHandle } from './index.js'
 
 vi.mock('node:dns/promises')
-global.fetch = vi.fn()
+globalThis.fetch = vi.fn()
 
 const mockLookup = vi.mocked(dns.lookup)
 

--- a/packages/fediverse/tsconfig.json
+++ b/packages/fediverse/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
   "extends": "@ykzts/tsconfig/basic.json",
   "include": ["src"]
 }

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "lint": "biome check .",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@vercel/microfrontends": "2.3.5",
@@ -34,6 +35,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "6.0.2",

--- a/packages/layout/tsconfig.json
+++ b/packages/layout/tsconfig.json
@@ -2,11 +2,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "paths": {
-      "@ykzts/layout/*": ["./src/*"],
-      "@ykzts/site-config": ["../site-config/src/index.ts"],
-      "@ykzts/supabase/*": ["../supabase/src/*"],
-      "@ykzts/ui/*": ["../ui/src/*"]
-    }
+      "@ykzts/layout/*": ["./src/*"]
+    },
+    "types": ["@testing-library/jest-dom", "node", "vitest/globals"]
   },
   "exclude": ["node_modules", "dist"],
   "extends": "@ykzts/tsconfig/next.json",

--- a/packages/pagination-utils/package.json
+++ b/packages/pagination-utils/package.json
@@ -7,7 +7,9 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "scripts": {},
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
   "dependencies": {},
   "devDependencies": {
     "@ykzts/tsconfig": "workspace:*",

--- a/packages/portable-text-editor/package.json
+++ b/packages/portable-text-editor/package.json
@@ -40,7 +40,8 @@
     "url": "https://github.com/ykzts/ykzts.git"
   },
   "scripts": {
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "type": "module",
   "version": "1.0.0"

--- a/packages/portable-text-editor/src/__tests__/portable-text-serializer.test.ts
+++ b/packages/portable-text-editor/src/__tests__/portable-text-serializer.test.ts
@@ -46,6 +46,25 @@ import {
   lexicalToPortableText
 } from '../portable-text-serializer'
 
+type PortableTextTestNode = {
+  _key: string
+  _type: string
+  alt: string
+  asset: { url: string }
+  children: Array<{ _key: string; _type: string; marks: string[]; text: string }>
+  language: string
+  level: number
+  listItem: string
+  markDefs: unknown[]
+  rows: Array<{
+    cells: Array<{ content: string; isHeader: boolean }>
+  }>
+  style: string
+}
+
+const toPortableText = (editor: ReturnType<typeof createEditor>) =>
+  lexicalToPortableText(editor) as unknown as PortableTextTestNode[]
+
 describe('Portable Text Serializer', () => {
   describe('lexicalToPortableText', () => {
     it('should serialize plain text to Portable Text', () => {
@@ -61,7 +80,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('block')
@@ -85,7 +104,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText[0].children[0].marks).toContain('strong')
       expect(portableText[0].children[0].text).toBe('bold text')
@@ -105,7 +124,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText[0].children[0].marks).toContain('em')
       expect(portableText[0].children[0].text).toBe('italic text')
@@ -125,7 +144,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText[0].children[0].marks).toContain('underline')
       expect(portableText[0].children[0].text).toBe('underline text')
@@ -145,7 +164,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText[0].children[0].marks).toContain('strike-through')
       expect(portableText[0].children[0].text).toBe('strikethrough text')
@@ -172,7 +191,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText[0].children[0].marks).toContain('code')
       expect(portableText[0].children[0].text).toBe('inline code')
@@ -195,7 +214,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText[0].children[0].marks).toContain('strong')
       expect(portableText[0].children[0].marks).toContain('em')
@@ -208,7 +227,7 @@ describe('Portable Text Serializer', () => {
         nodes: [LinkNode, ImageNode, ListNode, ListItemNode]
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0].children[0].text).toBe('')
@@ -233,7 +252,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph1, paragraph2)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(2)
       expect(portableText[0].children[0].text).toBe('First paragraph')
@@ -473,7 +492,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -481,7 +500,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].children[0].text).toBe('Test content')
     })
@@ -501,7 +520,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -509,7 +528,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].children[0].marks).toContain('strong')
       expect(portableText2[0].children[0].marks).toContain('em')
@@ -532,7 +551,7 @@ describe('Portable Text Serializer', () => {
         root.append(imageNode)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('image')
@@ -588,7 +607,7 @@ describe('Portable Text Serializer', () => {
         root.append(imageNode)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -596,7 +615,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2).toHaveLength(1)
       expect(portableText2[0]._type).toBe('image')
@@ -636,7 +655,7 @@ describe('Portable Text Serializer', () => {
         root.append(paragraph2)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(3)
       expect(portableText[0]._type).toBe('block')
@@ -733,7 +752,7 @@ describe('Portable Text Serializer', () => {
         root.append(list)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(2)
       expect(portableText[0]._type).toBe('block')
@@ -763,7 +782,7 @@ describe('Portable Text Serializer', () => {
         root.append(list)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(2)
       expect(portableText[0]._type).toBe('block')
@@ -893,7 +912,7 @@ describe('Portable Text Serializer', () => {
         root.append(list)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -901,7 +920,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].listItem).toBe('bullet')
       expect(portableText2[0].children[0].marks).toContain('strong')
@@ -1002,7 +1021,7 @@ describe('Portable Text Serializer', () => {
         root.append(outerList)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       // Should have 5 blocks: 3 at level 1, 2 at level 2
       expect(portableText).toHaveLength(5)
@@ -1071,7 +1090,7 @@ describe('Portable Text Serializer', () => {
         root.append(list1)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(3)
       expect(portableText[0].level).toBe(1)
@@ -1117,7 +1136,7 @@ describe('Portable Text Serializer', () => {
         root.append(outerList)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(3)
       expect(portableText[0].listItem).toBe('number')
@@ -1263,7 +1282,7 @@ describe('Portable Text Serializer', () => {
         root.append(list)
       })
 
-      const portableText1 = lexicalToPortableText(editor1)
+      const portableText1 = toPortableText(editor1)
       const json = JSON.stringify(portableText1)
 
       const editor2 = createEditor({
@@ -1278,7 +1297,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2).toHaveLength(3)
       expect(portableText2[0].level).toBe(1)
@@ -1333,7 +1352,7 @@ describe('Portable Text Serializer', () => {
 
       initializeEditorWithPortableText(editor, json)
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(3)
       expect(portableText[0].listItem).toBe('bullet')
@@ -1420,7 +1439,7 @@ describe('Portable Text Serializer', () => {
         root.append(heading)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('block')
@@ -1440,7 +1459,7 @@ describe('Portable Text Serializer', () => {
         root.append(heading)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('block')
@@ -1464,7 +1483,7 @@ describe('Portable Text Serializer', () => {
         root.append(h4, h5, h6)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(3)
       expect(portableText[0].style).toBe('h4')
@@ -1576,7 +1595,7 @@ describe('Portable Text Serializer', () => {
         root.append(heading)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -1584,7 +1603,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].style).toBe('h2')
       expect(portableText2[0].children[0].marks).toContain('strong')
@@ -1657,7 +1676,7 @@ describe('Portable Text Serializer', () => {
         root.append(quote)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('block')
@@ -1720,7 +1739,7 @@ describe('Portable Text Serializer', () => {
         root.append(quote)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -1735,7 +1754,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].style).toBe('blockquote')
       expect(portableText2[0].children[0].marks).toContain('strong')
@@ -1816,7 +1835,7 @@ describe('Portable Text Serializer', () => {
         root.append(code)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('block')
@@ -1881,7 +1900,7 @@ describe('Portable Text Serializer', () => {
         root.append(code)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -1898,7 +1917,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].style).toBe('code')
       expect(portableText2[0].children[0].text).toBe(
@@ -1927,7 +1946,7 @@ describe('Portable Text Serializer', () => {
         root.append(code)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('block')
@@ -1995,7 +2014,7 @@ describe('Portable Text Serializer', () => {
         root.append(code)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -2012,7 +2031,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0].style).toBe('code')
       expect(portableText2[0].language).toBe('python')
@@ -2040,7 +2059,7 @@ describe('Portable Text Serializer', () => {
         root.append(tableNode)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
 
       expect(portableText).toHaveLength(1)
       expect(portableText[0]._type).toBe('table')
@@ -2149,7 +2168,7 @@ describe('Portable Text Serializer', () => {
         root.append(tableNode)
       })
 
-      const portableText = lexicalToPortableText(editor)
+      const portableText = toPortableText(editor)
       const json = JSON.stringify(portableText)
 
       const editor2 = createEditor({
@@ -2165,7 +2184,7 @@ describe('Portable Text Serializer', () => {
       })
       initializeEditorWithPortableText(editor2, json)
 
-      const portableText2 = lexicalToPortableText(editor2)
+      const portableText2 = toPortableText(editor2)
 
       expect(portableText2[0]._type).toBe('table')
       if (portableText2[0]._type === 'table') {

--- a/packages/portable-text-utils/package.json
+++ b/packages/portable-text-utils/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@portabletext/markdown": "1.3.2",

--- a/packages/portable-text-utils/src/index.test.ts
+++ b/packages/portable-text-utils/src/index.test.ts
@@ -273,7 +273,7 @@ describe('portableTextToHTML', () => {
       }
     ]
     const result = portableTextToHTML(
-      content as Parameters<typeof portableTextToHTML>[0]
+      content as unknown as Parameters<typeof portableTextToHTML>[0]
     )
     expect(result).toContain('<figure>')
     expect(result).toContain('<img')
@@ -290,7 +290,7 @@ describe('portableTextToHTML', () => {
       }
     ]
     const result = portableTextToHTML(
-      content as Parameters<typeof portableTextToHTML>[0]
+      content as unknown as Parameters<typeof portableTextToHTML>[0]
     )
     expect(result).toContain('<figure>')
     expect(result).toContain('<img')
@@ -306,7 +306,7 @@ describe('portableTextToHTML', () => {
       }
     ]
     const result = portableTextToHTML(
-      content as Parameters<typeof portableTextToHTML>[0]
+      content as unknown as Parameters<typeof portableTextToHTML>[0]
     )
     expect(result).toContain('const x = 1')
     expect(result).toContain('<pre>')
@@ -321,7 +321,7 @@ describe('portableTextToHTML', () => {
       }
     ]
     const result = portableTextToHTML(
-      content as Parameters<typeof portableTextToHTML>[0]
+      content as unknown as Parameters<typeof portableTextToHTML>[0]
     )
     expect(result).toContain('hello world')
     expect(result).toContain('<pre>')

--- a/packages/site-config/package.json
+++ b/packages/site-config/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/site-config/tsconfig.json
+++ b/packages/site-config/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "extends": "@ykzts/tsconfig/react-library.json",
   "include": ["src"]
 }

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -54,6 +54,7 @@
     "url": "https://github.com/ykzts/ykzts.git"
   },
   "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "./scripts/typegen.sh"
   },
   "type": "module",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "./components/field": "./src/components/field.tsx",
     "./components/input": "./src/patches/input.tsx",
     "./components/label": "./src/components/label.tsx",
+    "./components/navigation-menu": "./src/components/navigation-menu.tsx",
     "./components/pagination": "./src/components/pagination.tsx",
     "./components/select": "./src/components/select.tsx",
     "./components/separator": "./src/components/separator.tsx",
@@ -27,7 +28,8 @@
     "./styles/theme.css": "./src/styles/theme.css"
   },
   "scripts": {
-    "lint": "biome check ."
+    "lint": "biome check .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@base-ui/react": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 2.107.0
       '@vercel/microfrontends':
         specifier: 2.3.5
-        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
+        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
       '@ykzts/fediverse':
         specifier: workspace:*
         version: link:../../packages/fediverse
@@ -164,10 +164,10 @@ importers:
         version: 2.107.0
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/microfrontends':
         specifier: 2.3.5
-        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
+        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
       '@ykzts/layout':
         specifier: workspace:*
         version: link:../../packages/layout
@@ -288,7 +288,7 @@ importers:
     dependencies:
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@ykzts/site-config':
         specifier: workspace:*
         version: link:../../packages/site-config
@@ -419,10 +419,10 @@ importers:
         version: 2.107.0
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/microfrontends':
         specifier: 2.3.5
-        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
+        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
       '@ykzts/layout':
         specifier: workspace:*
         version: link:../../packages/layout
@@ -583,7 +583,7 @@ importers:
     dependencies:
       '@vercel/microfrontends':
         specifier: 2.3.5
-        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
+        version: 2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))
       '@ykzts/site-config':
         specifier: workspace:*
         version: link:../site-config
@@ -615,6 +615,9 @@ importers:
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.16
@@ -9036,7 +9039,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vercel/analytics@2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -9047,7 +9050,7 @@ snapshots:
       pretty-cache-header: 1.0.0
       zod: 3.25.76
 
-  '@vercel/microfrontends@2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vercel/microfrontends@2.3.5(@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@next/env': 16.0.10
       '@types/md5': 2.3.6
@@ -9062,7 +9065,7 @@ snapshots:
       path-to-regexp: 6.3.0
       semver: 7.8.1
     optionalDependencies:
-      '@vercel/analytics': 2.0.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/analytics': 2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,10 @@
       "dependsOn": ["^build"],
       "outputs": ["test-results/**", "playwright-report/**"]
     },
+    "typecheck": {
+      "dependsOn": ["^typecheck", "^typegen", "typegen"],
+      "outputs": []
+    },
     "typegen": {
       "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],


### PR DESCRIPTION
## Summary
- add monorepo `typecheck` execution flow via Turbo and root script
- make `typecheck` depend on `typegen` to avoid missing generated types
- add/align `typecheck` scripts in workspace packages and apps
- resolve TypeScript 6 diagnostics in tests and package typings
- keep Vercel module ambient declarations minimal and document them with TODO comments

## Verification
- `pnpm typecheck`