### PR TITLE
fix: run `pnpm check --write --unsafe`

### DIFF
--- a/apps/blog/additional.d.ts
+++ b/apps/blog/additional.d.ts
@@ -2,7 +2,9 @@
 // @vercel/microfrontends/* and @vercel/analytics/react is stable in monorepo typecheck.
 declare module '@vercel/microfrontends/next/client' {
   export const Link: import('react').ComponentType<Record<string, unknown>>
-  export const PrefetchCrossZoneLinks: import('react').ComponentType<Record<string, never>>
+  export const PrefetchCrossZoneLinks: import('react').ComponentType<
+    Record<string, never>
+  >
   export const PrefetchCrossZoneLinksProvider: import('react').ComponentType<{
     children?: import('react').ReactNode
   }>

--- a/apps/blog/app/api/blog/draft/route.ts
+++ b/apps/blog/app/api/blog/draft/route.ts
@@ -46,7 +46,10 @@ export async function GET(request: NextRequest) {
 
     if (post) {
       return NextResponse.redirect(
-        new URL(`/blog/draft/${encodeURIComponent(post.slug as string)}`, request.url)
+        new URL(
+          `/blog/draft/${encodeURIComponent(post.slug as string)}`,
+          request.url
+        )
       )
     }
   } catch (error) {

--- a/apps/blog/components/portable-text.tsx
+++ b/apps/blog/components/portable-text.tsx
@@ -5,7 +5,7 @@ import {
   type PortableTextReactComponents
 } from '@portabletext/react'
 import Image from 'next/image'
-import { Suspense, type ComponentProps } from 'react'
+import { type ComponentProps, Suspense } from 'react'
 import Link from '@/components/link'
 import { generateHeadingId } from '@/lib/extract-headings'
 import type {

--- a/apps/portfolio/additional.d.ts
+++ b/apps/portfolio/additional.d.ts
@@ -5,7 +5,9 @@
 
 declare module '@vercel/microfrontends/next/client' {
   export const Link: import('react').ComponentType<Record<string, unknown>>
-  export const PrefetchCrossZoneLinks: import('react').ComponentType<Record<string, never>>
+  export const PrefetchCrossZoneLinks: import('react').ComponentType<
+    Record<string, never>
+  >
   export const PrefetchCrossZoneLinksProvider: import('react').ComponentType<{
     children?: import('react').ReactNode
   }>

--- a/packages/fediverse/src/index.test.ts
+++ b/packages/fediverse/src/index.test.ts
@@ -1,6 +1,9 @@
 import * as dns from 'node:dns/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { extractFediverseHandleFromURL, verifyFediverseHandle } from './index.js'
+import {
+  extractFediverseHandleFromURL,
+  verifyFediverseHandle
+} from './index.js'
 
 vi.mock('node:dns/promises')
 globalThis.fetch = vi.fn()

--- a/packages/portable-text-editor/src/__tests__/portable-text-serializer.test.ts
+++ b/packages/portable-text-editor/src/__tests__/portable-text-serializer.test.ts
@@ -51,7 +51,12 @@ type PortableTextTestNode = {
   _type: string
   alt: string
   asset: { url: string }
-  children: Array<{ _key: string; _type: string; marks: string[]; text: string }>
+  children: Array<{
+    _key: string
+    _type: string
+    marks: string[]
+    text: string
+  }>
   language: string
   level: number
   listItem: string


### PR DESCRIPTION
This pull request primarily includes minor code style improvements and formatting changes across several files to enhance readability and maintain consistency. No functional changes or new features are introduced.

Code formatting and import ordering:

* Reordered imports in `portable-text.tsx` to place `type` imports before value imports, aligning with best practices.
* Reformatted multiline object and function parameters for improved readability in `route.ts` and `index.test.ts`. [[1]](diffhunk://#diff-b1c7913cb961072e9bd43983aff262641e7b7afa8aca00112dcbd5a2df78fcebL49-R52) [[2]](diffhunk://#diff-83c6db2f0edbb361a3d12dfc7c6ba83369ea3616b6065802c0c6a4b7cbefd74fL3-R6)
* Reformatted the `children` property in the `PortableTextTestNode` type to a multiline format for better clarity in `portable-text-serializer.test.ts`.