### PR TITLE
fix(test): clean up pnpm test output

### DIFF
--- a/apps/blog/app/api/blog/cron/publish/__tests__/route.test.ts
+++ b/apps/blog/app/api/blog/cron/publish/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock environment variable
 vi.stubEnv('CRON_SECRET', 'test-cron-secret')
@@ -22,6 +22,11 @@ vi.mock('@/lib/supabase/client', () => ({
 describe('GET /api/cron/publish', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should return 401 for missing authorization header', async () => {

--- a/apps/blog/app/api/blog/search/__tests__/route.test.ts
+++ b/apps/blog/app/api/blog/search/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock Supabase client
 const mockRpc = vi.fn()
@@ -20,6 +20,11 @@ vi.mock('@/lib/embeddings', () => ({
 describe('POST /api/blog/search', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should return 400 for invalid JSON body', async () => {

--- a/apps/blog/vitest.config.ts
+++ b/apps/blog/vitest.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
+  resolve: {
+    tsconfigPaths: true
+  },
   test: {
     environment: 'jsdom',
     exclude: ['**/node_modules/**', '**/e2e/**'],

--- a/apps/portfolio/app/_actions/__tests__/contact.test.ts
+++ b/apps/portfolio/app/_actions/__tests__/contact.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock environment variables
 vi.stubEnv('RESEND_API_KEY', 'test_api_key')
@@ -37,6 +37,11 @@ global.fetch = vi.fn()
 describe('Contact form action', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('submitContactForm', () => {

--- a/apps/portfolio/app/_components/__tests__/contact.test.tsx
+++ b/apps/portfolio/app/_components/__tests__/contact.test.tsx
@@ -12,6 +12,11 @@ vi.mock('../contact-form', () => ({
   default: () => <div data-testid="contact-form">Contact Form</div>
 }))
 
+// Mock the async server-rendered SocialLinks subtree to keep this test focused.
+vi.mock('../social-links', () => ({
+  default: () => <div data-testid="social-links">Social Links</div>
+}))
+
 // Mock getProfile from @ykzts/supabase/queries
 vi.mock('@ykzts/supabase/queries', () => ({
   getProfile: vi.fn(async () => ({
@@ -38,17 +43,15 @@ vi.mock('@ykzts/supabase/queries', () => ({
 }))
 
 describe('Contact Component', () => {
-  it('renders with id="contact"', async () => {
-    const ContactElement = await Contact()
-    render(ContactElement)
+  it('renders with id="contact"', () => {
+    render(<Contact />)
 
     const section = document.querySelector('section')
     expect(section).toHaveAttribute('id', 'contact')
   })
 
-  it('renders the section title', async () => {
-    const ContactElement = await Contact()
-    const { container } = render(ContactElement)
+  it('renders the section title', () => {
+    const { container } = render(<Contact />)
 
     const heading = container.querySelector('h2')
     expect(heading).toBeInTheDocument()

--- a/apps/portfolio/vitest.config.ts
+++ b/apps/portfolio/vitest.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
+  resolve: {
+    tsconfigPaths: true
+  },
   test: {
     environment: 'jsdom',
     exclude: ['**/node_modules/**', '**/e2e/**'],

--- a/packages/layout/vitest.config.ts
+++ b/packages/layout/vitest.config.ts
@@ -1,9 +1,11 @@
 import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
+  resolve: {
+    tsconfigPaths: true
+  },
   test: {
     environment: 'jsdom',
     exclude: ['**/node_modules/**'],

--- a/packages/portable-text-editor/src/__tests__/portable-text-serializer.test.ts
+++ b/packages/portable-text-editor/src/__tests__/portable-text-serializer.test.ts
@@ -39,7 +39,7 @@ import {
   $isTextNode,
   createEditor
 } from 'lexical'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { $createImageNode, $isImageNode, ImageNode } from '../nodes/image-node'
 import {
   initializeEditorWithPortableText,
@@ -473,7 +473,13 @@ describe('Portable Text Serializer', () => {
         nodes: [LinkNode, ImageNode, ListNode, ListItemNode]
       })
 
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
       initializeEditorWithPortableText(editor, 'invalid json')
+
+      consoleErrorSpy.mockRestore()
 
       // Should not throw and editor should remain usable
       editor.read(() => {


### PR DESCRIPTION
## Summary
- replace deprecated `vite-tsconfig-paths` usage in affected Vitest configs with Vite's native `resolve.tsconfigPaths` option
- silence expected `console.error` output in failure-path tests so `pnpm test` does not emit noisy stderr logs
- mock the async social links subtree in the portfolio contact test to avoid React async component warnings

## Verification
- `pnpm test`