### PR TITLE
fix(workspace): align turbo schema and task outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,17 +1,11 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "./node_modules/turbo/schema.json",
   "globalDependencies": ["**/.env.*local"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
-      "outputs": [
-        ".docusaurus/**",
-        ".next/**",
-        "!.next/cache/**",
-        "build/**",
-        "dist/**"
-      ]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "dev": {
       "cache": false,
@@ -39,11 +33,10 @@
       "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
       "outputs": [
-        ".docusaurus/**",
         ".next/**",
         "!.next/cache/**",
-        "build/**",
-        "dist/**"
+        "dist/**",
+        "src/database.types.ts"
       ]
     },
     "validate": {}


### PR DESCRIPTION
## Summary
- switch `turbo.json` `$schema` from remote URL to local `./node_modules/turbo/schema.json`
- remove stale task outputs (`.docusaurus/**`, `build/**`) from `build`/`typegen`
- add `src/database.types.ts` to `typegen` outputs for Supabase type generation cache tracking

## Why
- avoid untrusted external schema warning in editors
- keep schema version aligned with installed Turbo package
- ensure Turbo output cache matches actual generated artifacts

## Validation
- `turbo.json` JSON parse check