### PR TITLE
fix(workspace): declare missing turbo env vars for vercel

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,19 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+      "env": [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "CRON_SECRET",
+        "DRAFT_SECRET",
+        "MAIL_FROM_ADDRESS",
+        "NODE_ENV",
+        "RESEND_API_KEY",
+        "REVALIDATE_SECRET",
+        "REVALIDATE_URLS",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "TURNSTILE_SECRET_KEY"
+      ],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "dev": {
@@ -14,7 +26,19 @@
     "lighthouse": {
       "cache": false,
       "dependsOn": ["^build", "build"],
-      "env": ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+      "env": [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "CRON_SECRET",
+        "DRAFT_SECRET",
+        "MAIL_FROM_ADDRESS",
+        "NODE_ENV",
+        "RESEND_API_KEY",
+        "REVALIDATE_SECRET",
+        "REVALIDATE_URLS",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "TURNSTILE_SECRET_KEY"
+      ],
       "outputs": [".lighthouseci/**"]
     },
     "test": {
@@ -31,7 +55,19 @@
     },
     "typegen": {
       "dependsOn": ["^build"],
-      "env": ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+      "env": [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "CRON_SECRET",
+        "DRAFT_SECRET",
+        "MAIL_FROM_ADDRESS",
+        "NODE_ENV",
+        "RESEND_API_KEY",
+        "REVALIDATE_SECRET",
+        "REVALIDATE_URLS",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "TURNSTILE_SECRET_KEY"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",


### PR DESCRIPTION
## Summary
- add missing environment variables referenced by source code to Turbo task `env` for `build`, `typegen`, and `lighthouse`
- keep `CI` intentionally excluded to avoid unintended cache behavior
- keep existing Supabase public env declarations and extend with server-side/runtime envs

## Why
Vercel + Turborepo warns when platform environment variables used by tasks are not accounted for in `turbo.json`.

## Notes
- This change focuses on declaration coverage only.
- No behavior change to application logic is intended.