### PR TITLE
fix(workspace): remove web fonts and align test outputs

### DIFF
--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -7,9 +7,7 @@ import Header from '@ykzts/layout/components/header'
 import SiteFooter from '@ykzts/layout/components/site-footer'
 import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
 import { getProfileOptional } from '@ykzts/supabase/queries'
-import { cn } from '@ykzts/ui/lib/utils'
 import type { Metadata, Viewport } from 'next'
-import { Inter, JetBrains_Mono, Noto_Sans_JP } from 'next/font/google'
 import AnalyticsClient from '@/components/analytics-client'
 import SearchForm from '@/components/search-form'
 import ThemeProvider from '@/components/theme-provider'
@@ -40,27 +38,6 @@ export const viewport: Viewport = {
   ]
 }
 
-const inter = Inter({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-inter',
-  weight: ['400', '500', '600', '700']
-})
-
-const jetBrainsMono = JetBrains_Mono({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
-  weight: ['400', '500']
-})
-
-const notoSansJp = Noto_Sans_JP({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-noto-sans-jp',
-  weight: ['400', '500', '600', '700']
-})
-
 export default function RootLayout({
   children
 }: {
@@ -68,12 +45,7 @@ export default function RootLayout({
 }) {
   return (
     <html
-      className={cn(
-        'scroll-smooth antialiased',
-        inter.variable,
-        jetBrainsMono.variable,
-        notoSansJp.variable
-      )}
+      className="scroll-smooth antialiased"
       lang="ja"
       suppressHydrationWarning
     >

--- a/apps/portfolio/app/layout.tsx
+++ b/apps/portfolio/app/layout.tsx
@@ -8,8 +8,6 @@ import { getSiteName, getSiteOrigin } from '@ykzts/site-config'
 import { getProfile } from '@ykzts/supabase/queries'
 import { Toaster } from '@ykzts/ui/components/sonner'
 import type { Metadata, Viewport } from 'next'
-import { Inter, JetBrains_Mono, Noto_Sans_JP } from 'next/font/google'
-import { twMerge } from 'tailwind-merge'
 import SVGSymbols from './_components/svg-symbols'
 import ThemeProvider from './_components/theme-provider'
 
@@ -45,36 +43,10 @@ export const viewport: Viewport = {
   ]
 }
 
-const inter = Inter({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-inter',
-  weight: ['400', '500', '600', '700']
-})
-
-const jetBrainsMono = JetBrains_Mono({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
-  weight: ['400', '500']
-})
-
-const notoSansJp = Noto_Sans_JP({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-noto-sans-jp',
-  weight: ['400', '500', '600', '700']
-})
-
 export default function RootLayout({ children, modal }: LayoutProps<'/'>) {
   return (
     <html
-      className={twMerge(
-        'scroll-smooth antialiased',
-        inter.variable,
-        jetBrainsMono.variable,
-        notoSansJp.variable
-      )}
+      className="scroll-smooth antialiased"
       lang="ja"
       suppressHydrationWarning
     >

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -5,11 +5,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans:
-    var(--font-inter), var(--font-noto-sans-jp), system-ui, sans-serif;
-  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
-  --font-heading:
-    var(--font-inter), var(--font-noto-sans-jp), system-ui, sans-serif;
+  --font-sans: system-ui, sans-serif;
+  --font-mono: ui-monospace, monospace;
+  --font-heading: system-ui, sans-serif;
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);

--- a/turbo.json
+++ b/turbo.json
@@ -43,7 +43,7 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "outputs": []
     },
     "test:a11y": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- remove `next/font` usage from `blog` and `portfolio` root layouts
- simplify shared font tokens in `packages/ui` to system font stacks only
- update Turbo `test` task outputs to `[]` to match current `vitest --run` behavior

## Why
- reduce LCP/CLS risks from Japanese web font loading and swap behavior
- keep typography consistent via OS-native fonts
- remove noisy Turbo warnings about missing test output artifacts

## Verification
- `pnpm check`
- `pnpm test`
- `pnpm -C apps/blog typecheck`
- `pnpm -C apps/portfolio typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * アプリケーション全体のフォント設定をシステムデフォルトに統一し、スタイルシートを簡素化しました。テーマのカスタム変数定義が更新されました。

* **Chores**
  * フォント関連の不要なインポートを削除しました。
  * テストタスクのキャッシュ設定を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->