### PR TITLE
chore: standardize development server ports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:3.0.1": {},
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {}
   },
-  "forwardPorts": [3000],
+  "forwardPorts": [3024, 3100, 3101, 3102, 54321, 54323, 54324],
   "hostRequirements": {
     "cpus": 4
   },
@@ -21,5 +21,38 @@
     "source=ykzts-com-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
   ],
   "name": "ykzts.com",
+  "otherPortsAttributes": {
+    "onAutoForward": "ignore"
+  },
+  "portsAttributes": {
+    "3024": {
+      "label": "Main Site (Microfrontends Proxy)",
+      "onAutoForward": "silent"
+    },
+    "3100": {
+      "label": "Admin Dev Server",
+      "onAutoForward": "silent"
+    },
+    "3101": {
+      "label": "Memo Dev Server",
+      "onAutoForward": "silent"
+    },
+    "3102": {
+      "label": "Blog Legacy Dev Server",
+      "onAutoForward": "silent"
+    },
+    "54321": {
+      "label": "Supabase API",
+      "onAutoForward": "silent"
+    },
+    "54323": {
+      "label": "Supabase Studio",
+      "onAutoForward": "silent"
+    },
+    "54324": {
+      "label": "Mailpit",
+      "onAutoForward": "silent"
+    }
+  },
   "postCreateCommand": "./.devcontainer/post-create.sh"
 }

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -6,7 +6,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 # Cache Revalidation
 # Comma-separated list of full revalidation endpoint URLs
 REVALIDATE_SECRET=your-secret-key
-REVALIDATE_URLS=http://localhost:3002/api/blog/revalidate,http://localhost:3000/api/revalidate
+REVALIDATE_URLS=http://localhost:3001/api/blog/revalidate,http://localhost:3000/api/revalidate
 
 # Cron Job Security
 # Secret for authenticating cron job requests (embedding generation)

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -26,7 +26,7 @@ pnpm install
 pnpm dev
 ```
 
-Visit http://localhost:3001/admin
+Visit http://localhost:3100/admin
 
 ## Environment Variables
 
@@ -41,7 +41,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 # Cache Revalidation
 # Comma-separated list of full revalidation endpoint URLs
 REVALIDATE_SECRET=your-secret-key
-REVALIDATE_URLS=http://localhost:3002/api/blog/revalidate,http://localhost:3000/api/revalidate
+REVALIDATE_URLS=http://localhost:3001/api/blog/revalidate,http://localhost:3000/api/revalidate
 
 # Cron Job Security
 CRON_SECRET=your-cron-secret

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "build": "next build",
-    "dev": "next dev --port 3001",
+    "dev": "next dev --port 3100",
     "start": "next start",
     "test": "vitest --run",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/blog-legacy/package.json
+++ b/apps/blog-legacy/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "next build",
-    "dev": "next dev --port 3003",
+    "dev": "next dev --port 3102",
     "start": "next start",
     "test": "vitest --run",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/memo/package.json
+++ b/apps/memo/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "next build",
-    "dev": "next dev --port 3003",
+    "dev": "next dev --port 3101",
     "start": "next start",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typegen": "next typegen"

--- a/apps/portfolio/microfrontends.json
+++ b/apps/portfolio/microfrontends.json
@@ -4,7 +4,7 @@
     "blog": {
       "development": {
         "fallback": "ykzts.com",
-        "local": 3002
+        "local": 3001
       },
       "packageName": "@ykzts/blog",
       "routing": [

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,9 +151,9 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3024"
+site_url = "http://localhost:3024"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3024"]
+additional_redirect_urls = ["http://localhost:3024"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,9 +151,9 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://127.0.0.1:3024"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["https://127.0.0.1:3024"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## Summary

Standardizes development server ports across the monorepo with a clear, logical separation:

### Microfrontends (main site, 3000s block)
- `portfolio` direct: 3000
- `blog` direct: 3001
- Proxy / entry point (the one you actually open): **3024** (unchanged default)

### Standalone / auxiliary apps (3100s block)
- `admin`: 3100
- `memo`: 3101
- `blog-legacy`: 3102

### Rationale
- 3000–3024 range is reserved for the composed ykzts.com experience (accessed primarily via the microfrontends proxy at 3024).
- 3100s range is used for directly runnable tools that do not participate in the microfrontends composition.
- This prevents port collisions when running multiple dev servers at once (e.g. `pnpm dev` / Turbo / inside the devcontainer).
- Direct child ports (3000/3001) are **intentionally not** exposed in devcontainer port forwarding or labels. Per the `@vercel/microfrontends` behavior, direct access to child apps is redirected to the proxy anyway, and internal calls (REVALIDATE etc.) work via localhost inside the container without forwarding.

## Changes
- Updated `dev` scripts in `apps/admin/package.json`, `apps/memo/package.json`, `apps/blog-legacy/package.json`
- Updated `local` hints in `apps/portfolio/microfrontends.json`
- Updated `.devcontainer/devcontainer.json`:
  - `forwardPorts` + detailed `portsAttributes` + labels only for user-facing / directly useful ports (3024 + 3100s + Supabase services)
  - `otherPortsAttributes` to ignore auto-forward for others (carried from initial work)
- Updated admin docs and environment examples (`apps/admin/README.md`, `.env.example`) for correct URLs and `REVALIDATE_URLS`
- Fixed `supabase/config.toml` auth `site_url` and `additional_redirect_urls` to point to the current main origin (3024)

## Verification
- Pre-commit hooks (ultracite + commitlint) passed
- Pre-push typecheck (`turbo run typecheck`) passed across the monorepo

This work originated from review of the initial devcontainer updates needed to support the additional apps (admin, memo, blog-legacy) alongside the microfrontends setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境のポート設定を更新しました。複数の開発サーバが異なるポート（3024、3100、3101、3102など）で実行されるようになります。ローカル開発時のアクセスURLが変更されているため、関連するドキュメントおよび環境変数設定を確認してください。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->