### PR TITLE
fix(admin, blog): set nativeButton correctly for Base UI render prop to suppress warnings

### DIFF
--- a/apps/admin/app/(authenticated)/layout.tsx
+++ b/apps/admin/app/(authenticated)/layout.tsx
@@ -44,6 +44,7 @@ async function UserInfo() {
         <DropdownMenuSeparator />
         <form action={logout}>
           <DropdownMenuItem
+            nativeButton={true}
             render={<button className="w-full text-left" type="submit" />}
           >
             ログアウト

--- a/apps/admin/app/(authenticated)/posts/[id]/versions/[versionId]/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/versions/[versionId]/page.tsx
@@ -123,12 +123,17 @@ async function VersionDetailContent({
 
       <div className="flex justify-between">
         <Button
+          nativeButton={false}
           render={<Link href={`/posts/${postId}/versions`} />}
           variant="outline"
         >
           履歴に戻る
         </Button>
-        <Button render={<Link href={`/posts/${postId}`} />} variant="outline">
+        <Button
+          nativeButton={false}
+          render={<Link href={`/posts/${postId}`} />}
+          variant="outline"
+        >
           投稿編集
         </Button>
       </div>

--- a/apps/admin/app/(authenticated)/posts/[id]/versions/compare/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/versions/compare/page.tsx
@@ -150,12 +150,17 @@ async function CompareContent({
 
       <div className="flex justify-between">
         <Button
+          nativeButton={false}
           render={<Link href={`/posts/${postId}/versions`} />}
           variant="outline"
         >
           履歴に戻る
         </Button>
-        <Button render={<Link href={`/posts/${postId}`} />} variant="outline">
+        <Button
+          nativeButton={false}
+          render={<Link href={`/posts/${postId}`} />}
+          variant="outline"
+        >
           投稿編集
         </Button>
       </div>
@@ -197,6 +202,7 @@ async function ComparePageContent({
           <p className="text-error">比較するバージョンが指定されていません</p>
           <Button
             className="mt-4"
+            nativeButton={false}
             render={<Link href={`/posts/${id}/versions`} />}
             variant="outline"
           >

--- a/apps/admin/app/(authenticated)/posts/[id]/versions/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/versions/page.tsx
@@ -77,6 +77,7 @@ async function VersionsContent({ postId }: { postId: string }) {
                   </div>
                   <div className="flex gap-2">
                     <Button
+                      nativeButton={false}
                       render={
                         <Link
                           href={`/posts/${postId}/versions/${version.id}`}
@@ -89,6 +90,7 @@ async function VersionsContent({ postId }: { postId: string }) {
                     </Button>
                     {index > 0 && (
                       <Button
+                        nativeButton={false}
                         render={
                           <Link
                             href={`/posts/${postId}/versions/compare?from=${versions[index].id}&to=${versions[0].id}`}
@@ -124,10 +126,18 @@ async function VersionsContent({ postId }: { postId: string }) {
       </Panel>
 
       <div className="flex justify-between">
-        <Button render={<Link href={`/posts/${postId}`} />} variant="outline">
+        <Button
+          nativeButton={false}
+          render={<Link href={`/posts/${postId}`} />}
+          variant="outline"
+        >
           投稿編集に戻る
         </Button>
-        <Button render={<Link href="/posts" />} variant="outline">
+        <Button
+          nativeButton={false}
+          render={<Link href="/posts" />}
+          variant="outline"
+        >
           一覧に戻る
         </Button>
       </div>

--- a/apps/admin/app/(authenticated)/posts/_components/new-post-button.tsx
+++ b/apps/admin/app/(authenticated)/posts/_components/new-post-button.tsx
@@ -4,5 +4,9 @@ import { Button } from "@ykzts/ui/components/button";
 import Link from "next/link";
 
 export function NewPostButton() {
-  return <Button render={<Link href="/posts/new" />}>新規作成</Button>;
+  return (
+    <Button nativeButton={false} render={<Link href="/posts/new" />}>
+      新規作成
+    </Button>
+  );
 }

--- a/apps/admin/app/(authenticated)/posts/_components/post-form.tsx
+++ b/apps/admin/app/(authenticated)/posts/_components/post-form.tsx
@@ -634,6 +634,7 @@ export function PostForm({
             </Button>
             <div className="flex gap-2">
               <Button
+                nativeButton={false}
                 render={<Link href="/posts" />}
                 type="button"
                 variant="outline"
@@ -648,6 +649,7 @@ export function PostForm({
         ) : (
           <div className="flex justify-end gap-2">
             <Button
+              nativeButton={false}
               render={<Link href="/posts" />}
               type="button"
               variant="outline"

--- a/apps/admin/app/(authenticated)/works/_components/new-work-button.tsx
+++ b/apps/admin/app/(authenticated)/works/_components/new-work-button.tsx
@@ -4,5 +4,9 @@ import { Button } from "@ykzts/ui/components/button";
 import Link from "next/link";
 
 export function NewWorkButton() {
-  return <Button render={<Link href="/works/new" />}>新規作成</Button>;
+  return (
+    <Button nativeButton={false} render={<Link href="/works/new" />}>
+      新規作成
+    </Button>
+  );
 }

--- a/apps/blog/components/link-button.tsx
+++ b/apps/blog/components/link-button.tsx
@@ -16,5 +16,11 @@ export default function LinkButton({
   href,
   ...props
 }: LinkButtonProps) {
-  return <Button render={<Link href={href}>{children}</Link>} {...props} />;
+  return (
+    <Button
+      nativeButton={false}
+      render={<Link href={href}>{children}</Link>}
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
## 概要

Admin などで表示されていた以下の Base UI 警告を解消しました。

```
Base UI: A component that acts as a button expected a non-<button> because the `nativeButton` prop is false. Rendering a <button> keeps native behavior while Base UI applies non-native attributes and handlers, which can add unintended extra attributes (such as `role` or `aria-disabled`). Use a non-<button> in the `render` prop, or set `nativeButton` to `true`.
```

## 原因

Base UI（`@base-ui/react`）の button として振る舞うコンポーネント（`Button`, `MenuItem`, `DialogTrigger` など）は内部で `useButton` を使っており、`nativeButton` prop によって期待する DOM 要素を制御しています。

- `nativeButton={true}`（デフォルト）：本物の `<button>` 要素を期待
- `nativeButton={false}`：`<a>` や `<div>` などの非 button 要素を期待（`role="button"` などを付与）

以下の箇所でミスマッチが発生していました：

- `DropdownMenuItem`（デフォルト `nativeButton=false`）に対して `render={<button type="submit">}` を渡していた（ログアウト処理）
- `@ykzts/ui` の `Button`（デフォルト `nativeButton=true`）に対して `render={<Link href="...">}`（実体は `<a>`）を渡していた多数の箇所

## 変更内容

- ログアウトの `<DropdownMenuItem>` に `nativeButton={true}` を明示
- Admin 内の各種 navigation / form cancel / new post ボタンなどで `Button` に `nativeButton={false}` を追加
- Blog アプリの `LinkButton` コンポーネントでも同様に修正

修正対象ファイル（8 ファイル）:
- `apps/admin/app/(authenticated)/layout.tsx`
- `apps/admin/app/(authenticated)/posts/_components/*.tsx`
- `apps/admin/app/(authenticated)/works/_components/new-work-button.tsx`
- `apps/admin/app/(authenticated)/posts/[id]/versions/**/*.tsx`
- `apps/blog/components/link-button.tsx`

## 副作用・影響

**ポジティブな影響**:
- 開発時のコンソール警告がなくなります。
- `nativeButton` の値と実際の要素が一致するようになり、Base UI が付与する属性（`type`, `role`, `aria-disabled` など）が意図したものになります。
- 特に `type="submit"` のケースでセマンティクスがより正確になります。

**考慮すべき点**:
- 既存の UI 動作・見た目・アクセシビリティ上の変更はありません（正しいモードで動作するようになっただけ）。
- 将来、同様のパターン（特に `Menu*Item` や `SelectItem` などで `render` に `<button>` を渡す場合）で同じ問題を避けるため、render を使う際は `nativeButton` を意識する必要があります。

## 検証

- `pnpm check`（ultracite / biome）: ✅ クリーン
- `turbo run typecheck`（pre-push hook で実行）: ✅ 全パッケージ成功
- lefthook フック（pre-commit, commit-msg, pre-push）: すべてパス
- 変更は最小限で、render prop の正しい使い方に沿った修正です。

Assisted-by: Grok Build (xAI)