### PR TITLE
feat(blog): add tag-specific Atom feeds and improve feed discoverability

### DIFF
--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -13,7 +13,7 @@ This application powers the blog section at [ykzts.com/blog](https://ykzts.com/b
 - **Supabase Integration**: PostgreSQL database for article management and storage
 - **AI-Powered Similar Posts**: Embedding-based similar article recommendations via Vercel AI SDK
 - **Vercel Analytics**: Performance monitoring and user analytics
-- **Atom Feed**: Syndication feed generated at `/blog.atom`
+- **Atom Feed**: Syndication feed generated at `/blog.atom` and tag-specific feeds at `/blog/tags/[tag].atom` (e.g. `/blog/tags/nextjs.atom`)
 - **Sitemap**: Auto-generated sitemap at `/blog/sitemap.xml`
 - **Full-Text Search**: Article search powered by Supabase
 - **Draft Mode**: Preview unpublished posts via secure draft endpoints

--- a/apps/blog/app/api/blog/tags/[tag]/atom/route.ts
+++ b/apps/blog/app/api/blog/tags/[tag]/atom/route.ts
@@ -1,0 +1,44 @@
+import { getSiteName, getSiteOrigin } from "@ykzts/site-config";
+import type { NextRequest } from "next/server";
+import { createAtomFeed } from "@/lib/feed";
+import { getPostsByTagForFeed } from "@/lib/supabase/posts";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ tag: string }> }
+) {
+  const { tag: rawTag } = await params;
+  const tag = decodeURIComponent(rawTag);
+
+  const posts = await getPostsByTagForFeed(tag);
+
+  if (posts.length === 0) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+  }
+
+  const siteOrigin = getSiteOrigin();
+  const encodedTag = encodeURIComponent(tag);
+  const tagUrl = new URL(`/blog/tags/${encodedTag}`, siteOrigin).toString();
+  const atomUrl = new URL(
+    `/blog/tags/${encodedTag}.atom`,
+    siteOrigin
+  ).toString();
+
+  const atom = await createAtomFeed(posts, {
+    atomLink: atomUrl,
+    description: `${tag}タグの記事`,
+    link: tagUrl,
+    title: `${tag} | Blog | ${getSiteName()}`,
+  });
+
+  return new Response(atom, {
+    headers: {
+      "Content-Type": "application/atom+xml; charset=utf-8",
+    },
+  });
+}

--- a/apps/blog/app/blog.atom/route.ts
+++ b/apps/blog/app/blog.atom/route.ts
@@ -1,83 +1,20 @@
 import { getSiteName, getSiteOrigin } from "@ykzts/site-config";
-import { getProfile } from "@ykzts/supabase/queries";
-import { portableTextToHTML } from "@ykzts/utils/portable-text";
-import { Feed } from "feed";
-import { DEFAULT_POST_TITLE } from "@/lib/constants";
+import { createAtomFeed } from "@/lib/feed";
 import { getPostsForFeed } from "@/lib/supabase/posts";
 
 export async function GET() {
   const posts = await getPostsForFeed(20);
 
-  let profileName: string | null = null;
-  try {
-    const profile = await getProfile();
-    if (profile.name?.trim()) {
-      profileName = profile.name.trim();
-    }
-  } catch (error) {
-    console.error("Failed to load publisher profile for atom feed:", error);
-  }
-
   const siteOrigin = getSiteOrigin();
   const baseUrl = new URL("/blog", siteOrigin).toString();
 
-  const feedAuthor = profileName
-    ? {
-        name: profileName,
-      }
-    : undefined;
-
-  const latestPostUpdatedAt =
-    posts.length > 0
-      ? posts.reduce((latest, post) => {
-          const postDate = new Date(post.version_date ?? post.published_at);
-          return postDate.getTime() > latest.getTime() ? postDate : latest;
-        }, new Date(0))
-      : undefined;
-
-  const feedCopyright = profileName
-    ? ["Copyright ©", latestPostUpdatedAt?.getFullYear(), profileName]
-        .filter(Boolean)
-        .join(" ")
-    : undefined;
-
-  const feed = new Feed({
-    author: feedAuthor,
-    copyright: feedCopyright,
-    description: "Blog",
-    favicon: new URL("/favicon.ico", siteOrigin).toString(),
-    feedLinks: {
-      atom: new URL("/blog.atom", siteOrigin).toString(),
-    },
-    generator: "Next.js with feed package",
-    id: baseUrl,
+  const atom = await createAtomFeed(posts, {
+    atomLink: new URL("/blog.atom", siteOrigin).toString(),
     link: baseUrl,
     title: `Blog | ${getSiteName()}`,
-    updated: latestPostUpdatedAt,
   });
 
-  for (const post of posts) {
-    const publishedDate = new Date(post.published_at);
-    const year = String(publishedDate.getUTCFullYear());
-    const month = String(publishedDate.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(publishedDate.getUTCDate()).padStart(2, "0");
-    const postUrl = new URL(
-      `/blog/${year}/${month}/${day}/${encodeURIComponent(post.slug)}`,
-      siteOrigin
-    ).toString();
-
-    feed.addItem({
-      content: portableTextToHTML(post.content),
-      date: post.version_date ? new Date(post.version_date) : publishedDate,
-      description: post.excerpt || undefined,
-      id: postUrl,
-      link: postUrl,
-      published: publishedDate,
-      title: post.title || DEFAULT_POST_TITLE,
-    });
-  }
-
-  return new Response(feed.atom1(), {
+  return new Response(atom, {
     headers: {
       "Content-Type": "application/atom+xml; charset=utf-8",
     },

--- a/apps/blog/app/blog/[year]/page.tsx
+++ b/apps/blog/app/blog/[year]/page.tsx
@@ -9,6 +9,7 @@ import {
   BreadcrumbSeparator,
 } from "@ykzts/ui/components/breadcrumb";
 import type { PortableTextValue } from "@ykzts/utils/portable-text";
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import PostCard from "@/components/post-card";
@@ -164,9 +165,21 @@ export default async function YearArchivePage({ params }: PageProps) {
           </BreadcrumbList>
         </Breadcrumb>
 
-        <h1 className="mb-4 font-bold text-3xl">
-          {year}年 ({count}件)
-        </h1>
+        <div className="mb-8 flex items-baseline justify-between">
+          <h1 className="font-bold text-3xl">
+            {year}年 ({count}件)
+          </h1>
+          <a
+            aria-label="ブログのAtomフィードを購読"
+            className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href="/blog.atom"
+            rel="alternate"
+            type="application/atom+xml"
+          >
+            <Rss className="h-4 w-4" />
+            <span>Atom</span>
+          </a>
+        </div>
 
         {availableMonths.length > 1 && (
           <nav

--- a/apps/blog/app/blog/page.tsx
+++ b/apps/blog/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import { getSiteName } from "@ykzts/site-config";
 import { getProfile } from "@ykzts/supabase/queries";
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { YearArchiveLinks } from "./_components/archive-links";
@@ -26,6 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
     alternates: {
       canonical: "/blog",
       types: {
+        "application/atom+xml": "/blog.atom",
         "text/markdown": "/blog.md",
       },
     },
@@ -46,6 +48,19 @@ export default function HomePage() {
   return (
     <main className="px-6 py-8 md:px-12 lg:px-24">
       <div className="mx-auto max-w-4xl">
+        <div className="mb-8 flex items-baseline justify-between">
+          <h1 className="font-bold text-3xl">ブログ</h1>
+          <a
+            aria-label="ブログのAtomフィードを購読"
+            className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href="/blog.atom"
+            rel="alternate"
+            type="application/atom+xml"
+          >
+            <Rss className="h-4 w-4" />
+            <span>Atom</span>
+          </a>
+        </div>
         <Suspense fallback={<PostsSkeleton count={5} />}>
           <Posts />
         </Suspense>

--- a/apps/blog/app/blog/tags/[tag]/layout.tsx
+++ b/apps/blog/app/blog/tags/[tag]/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+interface TagLayoutProps {
+  children: ReactNode;
+  params: Promise<{ tag: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: TagLayoutProps): Promise<Metadata> {
+  const { tag } = await params;
+  const decodedTag = decodeURIComponent(tag);
+  const encodedTag = encodeURIComponent(decodedTag);
+
+  return {
+    alternates: {
+      types: {
+        "application/atom+xml": `/blog/tags/${encodedTag}.atom`,
+      },
+    },
+  };
+}
+
+export default function TagLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/blog/app/blog/tags/[tag]/page.tsx
+++ b/apps/blog/app/blog/tags/[tag]/page.tsx
@@ -7,6 +7,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@ykzts/ui/components/breadcrumb";
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import BlogPagination from "@/components/blog-pagination";
@@ -77,9 +78,21 @@ export default async function TagArchivePage({ params }: PageProps) {
           </BreadcrumbList>
         </Breadcrumb>
 
-        <h1 className="mb-8 font-bold text-3xl">
-          {decodedTag} ({postCount}件)
-        </h1>
+        <div className="mb-8 flex items-baseline justify-between">
+          <h1 className="font-bold text-3xl">
+            {decodedTag} ({postCount}件)
+          </h1>
+          <a
+            aria-label={`${decodedTag}タグのAtomフィードを購読`}
+            className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href={`/blog/tags/${encodeURIComponent(decodedTag)}.atom`}
+            rel="alternate"
+            type="application/atom+xml"
+          >
+            <Rss className="h-4 w-4" />
+            <span>Atom</span>
+          </a>
+        </div>
         <div className="space-y-6">
           {posts.map((post) => (
             <PostCard key={post.id} post={post} />

--- a/apps/blog/app/blog/tags/[tag]/page/[num]/page.tsx
+++ b/apps/blog/app/blog/tags/[tag]/page/[num]/page.tsx
@@ -1,3 +1,4 @@
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import BlogPagination from "@/components/blog-pagination";
@@ -68,9 +69,21 @@ export default async function TagPaginationPage({ params }: PageProps) {
   return (
     <main className="px-6 py-8 md:px-12 lg:px-24">
       <div className="mx-auto max-w-4xl">
-        <h1 className="mb-8 font-bold text-3xl">
-          {decodedTag} ({postCount}件)
-        </h1>
+        <div className="mb-8 flex items-baseline justify-between">
+          <h1 className="font-bold text-3xl">
+            {decodedTag} ({postCount}件)
+          </h1>
+          <a
+            aria-label={`${decodedTag}タグのAtomフィードを購読`}
+            className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+            href={`/blog/tags/${encodeURIComponent(decodedTag)}.atom`}
+            rel="alternate"
+            type="application/atom+xml"
+          >
+            <Rss className="h-4 w-4" />
+            <span>Atom</span>
+          </a>
+        </div>
         <div className="space-y-6">
           {posts.map((post) => (
             <PostCard key={post.id} post={post} />

--- a/apps/blog/lib/feed.ts
+++ b/apps/blog/lib/feed.ts
@@ -1,0 +1,95 @@
+import type { PortableTextBlock } from "@portabletext/types";
+import { getSiteOrigin } from "@ykzts/site-config";
+import { getProfile } from "@ykzts/supabase/queries";
+import { portableTextToHTML } from "@ykzts/utils/portable-text";
+import { Feed } from "feed";
+import { DEFAULT_POST_TITLE } from "@/lib/constants";
+
+export interface FeedItemInput {
+  content: PortableTextBlock[] | null | undefined;
+  excerpt?: string | null;
+  published_at: string;
+  slug: string;
+  title?: string | null;
+  version_date?: string | null;
+}
+
+export async function createAtomFeed(
+  items: FeedItemInput[],
+  feedOptions: {
+    title: string;
+    description?: string;
+    link: string;
+    atomLink: string;
+  }
+): Promise<string> {
+  let profileName: string | null = null;
+  try {
+    const profile = await getProfile();
+    if (profile.name?.trim()) {
+      profileName = profile.name.trim();
+    }
+  } catch (error) {
+    console.error("Failed to load publisher profile for atom feed:", error);
+  }
+
+  const siteOrigin = getSiteOrigin();
+
+  const feedAuthor = profileName
+    ? {
+        name: profileName,
+      }
+    : undefined;
+
+  const latestPostUpdatedAt =
+    items.length > 0
+      ? items.reduce((latest, post) => {
+          const postDate = new Date(post.version_date ?? post.published_at);
+          return postDate.getTime() > latest.getTime() ? postDate : latest;
+        }, new Date(0))
+      : undefined;
+
+  const feedCopyright = profileName
+    ? ["Copyright ©", latestPostUpdatedAt?.getFullYear(), profileName]
+        .filter(Boolean)
+        .join(" ")
+    : undefined;
+
+  const feed = new Feed({
+    author: feedAuthor,
+    copyright: feedCopyright,
+    description: feedOptions.description ?? "Blog",
+    favicon: new URL("/favicon.ico", siteOrigin).toString(),
+    feedLinks: {
+      atom: feedOptions.atomLink,
+    },
+    generator: "Next.js with feed package",
+    id: feedOptions.link,
+    link: feedOptions.link,
+    title: feedOptions.title,
+    updated: latestPostUpdatedAt,
+  });
+
+  for (const post of items) {
+    const publishedDate = new Date(post.published_at);
+    const year = String(publishedDate.getUTCFullYear());
+    const month = String(publishedDate.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(publishedDate.getUTCDate()).padStart(2, "0");
+    const postUrl = new URL(
+      `/blog/${year}/${month}/${day}/${encodeURIComponent(post.slug)}`,
+      siteOrigin
+    ).toString();
+
+    feed.addItem({
+      content: portableTextToHTML(post.content),
+      date: post.version_date ? new Date(post.version_date) : publishedDate,
+      description: post.excerpt || undefined,
+      id: postUrl,
+      link: postUrl,
+      published: publishedDate,
+      title: post.title || DEFAULT_POST_TITLE,
+    });
+  }
+
+  return feed.atom1();
+}

--- a/apps/blog/lib/supabase/posts.ts
+++ b/apps/blog/lib/supabase/posts.ts
@@ -16,6 +16,15 @@ function getClient(isDraft = false) {
 
 const POSTS_PER_PAGE = 10;
 
+/**
+ * Maximum number of posts to include in Atom feeds.
+ * Main feed uses a smaller number (20). Tag feeds use this as default.
+ * We intentionally do not return "all" posts even for tags, as that can make
+ * the feed response very large (full content via portableTextToHTML is included
+ * for each item) and put unnecessary load on the database and feed readers.
+ */
+const FEED_LIMIT = 50;
+
 type Profile = {
   fediverse_creator?: string | null;
   id: string;
@@ -388,15 +397,15 @@ export async function getAdjacentYears(
   return { previousYear, nextYear };
 }
 
-export async function getPostsForFeed(limit = 20) {
-  cacheTag("posts");
+async function fetchFeedPosts(options: { limit?: number; tag?: string } = {}) {
+  const { limit, tag } = options;
 
   if (!supabase) {
     // Return empty array when Supabase is not configured (e.g., during build without env vars)
     return [];
   }
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("posts")
     .select(
       `
@@ -412,9 +421,21 @@ export async function getPostsForFeed(limit = 20) {
     )
     .eq("status", "published")
     .lte("published_at", new Date().toISOString())
-    .not("slug", "is", null)
-    .order("published_at", { ascending: false })
-    .limit(limit);
+    .not("slug", "is", null);
+
+  if (tag) {
+    query = query.contains("tags", [tag]);
+  }
+
+  query = query.order("published_at", { ascending: false });
+
+  // Always apply a limit. Callers can pass a specific number (main feed passes 20).
+  // If no explicit limit, fall back to FEED_LIMIT. This prevents accidentally
+  // returning every matching post, which would be heavy for feeds.
+  const effectiveLimit = limit != null && limit > 0 ? limit : FEED_LIMIT;
+  query = query.limit(effectiveLimit);
+
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`Failed to fetch posts for feed: ${error.message}`);
@@ -430,6 +451,26 @@ export async function getPostsForFeed(limit = 20) {
     title: post.title as string,
     version_date: extractVersionDate(post.current_version),
   }));
+}
+
+export async function getPostsForFeed(limit = 20) {
+  cacheTag("posts");
+
+  return await fetchFeedPosts({ limit });
+}
+
+/**
+ * Fetch posts for a tag-specific Atom feed.
+ * Returns at most the most recent FEED_LIMIT posts for the tag (default 50).
+ * We cap the number instead of returning every post for the tag because:
+ * - Full post content (via portableTextToHTML) is embedded for each item.
+ * - Large feeds hurt performance, bandwidth, and feed reader experience.
+ * - "Latest N for this tag" is the useful behavior for subscribers.
+ */
+export async function getPostsByTagForFeed(tag: string, limit = FEED_LIMIT) {
+  cacheTag("posts");
+
+  return await fetchFeedPosts({ tag, limit });
 }
 
 export async function getTotalPostCount(isDraft = false) {

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -17,6 +17,16 @@ const nextConfig: NextConfig = {
       permanent: true,
       source: "/blog/atom.xml",
     },
+    {
+      destination: "/blog/tags/:tag.atom",
+      permanent: true,
+      source: "/blog/tags/:tag/atom",
+    },
+    {
+      destination: "/blog/tags/:tag.atom",
+      permanent: true,
+      source: "/blog/tags/:tag/atom.xml",
+    },
   ],
   rewrites: async () => ({
     beforeFiles: [
@@ -27,6 +37,10 @@ const nextConfig: NextConfig = {
       {
         destination: "/api/blog/markdown/:year/:month/:day/:slug",
         source: "/blog/:year/:month/:day/:slug.md",
+      },
+      {
+        destination: "/api/blog/tags/:tag/atom",
+        source: "/blog/tags/:tag.atom",
       },
     ],
   }),


### PR DESCRIPTION
## Summary

Implements https://github.com/ykzts/ykzts/issues/4019.

- Support for tag-specific Atom feeds at `/blog/tags/[tag].atom` (e.g. `/blog/tags/nextjs.atom`).
- Uses `beforeFiles` rewrite + dedicated API handler under `/api/blog/tags/[tag]/atom` (mirrors the existing Markdown `.md` rewrite pattern to remain compatible with `typedRoutes: true` and `RouteHandlerConfig`).
- `getPostsByTagForFeed` (backed by `FEED_LIMIT=50`) returns the **most recent** posts for a tag instead of all (avoids heavy responses since `portableTextToHTML` full content is included per item).
- Visible Atom feed links (with Rss icon) using `justify-between` layout next to page titles for discoverability on:
  - Main blog top page (`/blog`, which now also renders an explicit `<h1>ブログ</h1>`)
  - Tag archive pages (index + `/page/[num]`)
  - Year archive pages (for consistency)
- Tag feed `alternates` metadata moved into the new `apps/blog/app/blog/tags/[tag]/layout.tsx` (eliminates duplication between the two page files).
- Shared feed generation logic in `lib/feed.ts`; main `/blog.atom` route updated to use it.
- Supporting: redirects (`.atom` forms canonical), rewrites, README, main blog metadata.

Closes #4019

## Verification

- `pnpm check`, typecheck (lefthook), `pnpm --filter @ykzts/blog build`, and tests all pass.
- Follows project conventions (Conventional Commits, Biome, RSC + App Router, etc.).

Assisted-by: Grok Build (xAI)
