### PR TITLE
fix(blog): fix Similar Posts card layout collapse

### DIFF
--- a/apps/blog/components/similar-posts-skeleton.tsx
+++ b/apps/blog/components/similar-posts-skeleton.tsx
@@ -19,7 +19,7 @@ export default function SimilarPostsSkeleton({
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {Array.from({ length: count }).map((_, index) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton items don't need unique keys
-          <Card aria-hidden="true" key={`skeleton-${index}`}>
+          <Card aria-hidden="true" className="h-full" key={`skeleton-${index}`}>
             <CardHeader>
               <Skeleton className="mb-2 h-6 w-full" />
               <Skeleton className="h-4 w-24" />
@@ -28,7 +28,7 @@ export default function SimilarPostsSkeleton({
               <Skeleton className="mb-1 h-4 w-full" />
               <Skeleton className="h-4 w-3/4" />
             </CardContent>
-            <CardFooter>
+            <CardFooter className="mt-auto">
               <div className="flex gap-2">
                 <Skeleton className="h-6 w-16" />
                 <Skeleton className="h-6 w-20" />

--- a/apps/blog/components/similar-posts.tsx
+++ b/apps/blog/components/similar-posts.tsx
@@ -45,7 +45,7 @@ export default function SimilarPosts({ posts }: SimilarPostsProps) {
           const previewText =
             post.excerpt || extractFirstParagraph(post.content);
           return (
-            <Card key={post.id}>
+            <Card className="h-full" key={post.id}>
               <CardHeader>
                 <CardTitle className="text-lg">
                   <Link className="hover:underline" href={url}>
@@ -64,7 +64,7 @@ export default function SimilarPosts({ posts }: SimilarPostsProps) {
                 </CardContent>
               )}
               {post.tags && post.tags.length > 0 && (
-                <CardFooter>
+                <CardFooter className="mt-auto">
                   <TagList className="flex flex-wrap gap-2" tags={post.tags} />
                 </CardFooter>
               )}


### PR DESCRIPTION
## Summary / 概要

記事詳細ページ下部の「関連記事（Similar Posts）」セクションで、カードの高さが揃わず、内部要素（日付・タグ）の位置がコンテンツ量によってガタつく問題を修正しました。

Fixes #4027

## Problem
- グリッドレイアウト内で `Card` の高さがタイトルの長さや抜粋/タグの有無に依存してバラバラになっていた。
- `CardFooter`（タグ部分）の垂直位置が不安定で、レスポンシブグリッド（2列/3列）で見た目が崩れていた。

## Solution
- Similar Posts のグリッド配下の各 `<Card>` に `h-full` を付与（グリッドセルの高さを埋める）。
- `<CardFooter>` に `mt-auto`（className経由）を付与。カードの高さがグリッドにより制約されたときにフッターを下端へピン留め。
- ローディング用のスケルトンにも同じクラスを適用して整合性を保つ。

リスト表示などで使われる垂直スタックのカード（PostCard など）には影響しません（高さ制約がないため `mt-auto` は 0 として扱われる）。

## Changes
- `apps/blog/components/similar-posts.tsx`
- `apps/blog/components/similar-posts-skeleton.tsx`

## Verification
- `pnpm check` (ultracite/Biome): passed
- `apps/blog` vitest: 101 tests passed (similar-posts 関連のテスト含む)
- Full monorepo typecheck (via lefthook pre-push): passed
- lefthook pre-commit / commit-msg / pre-push hooks: all green

## Related
- Issue: https://github.com/ykzts/ykzts/issues/4027

Assisted-by: Grok Build (xAI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 関連記事カードのレイアウトを改善し、全てのカードの高さが統一されるように修正しました。
  * カードフッター要素がカード下部に正しく配置されるように調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->