### PR TITLE
fix: add missing data-scroll-behavior attribute

### DIFF
--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -46,6 +46,7 @@ export default function RootLayout({
   return (
     <html
       className="scroll-smooth antialiased"
+      data-scroll-behavior="smooth"
       lang="ja"
       suppressHydrationWarning
     >

--- a/apps/portfolio/app/layout.tsx
+++ b/apps/portfolio/app/layout.tsx
@@ -47,6 +47,7 @@ export default function RootLayout({ children, modal }: LayoutProps<"/">) {
   return (
     <html
       className="scroll-smooth antialiased"
+      data-scroll-behavior="smooth"
       lang="ja"
       suppressHydrationWarning
     >


### PR DESCRIPTION
## Summary

Added the \`data-scroll-behavior="smooth"\` attribute to the root \`<html>\` elements.

This resolves the Next.js [missing-data-scroll-behavior](https://nextjs.org/docs/messages/missing-data-scroll-behavior) warning.

## Background

The portfolio and (new) blog apps use Tailwind's \`scroll-smooth\` class on \`<html>\`, which sets \`scroll-behavior: smooth\` in CSS. Next.js warns when it detects this without the data attribute, because it wants to be able to disable smooth scrolling temporarily during SPA navigations.

## Changes

- apps/portfolio/app/layout.tsx
- apps/blog/app/layout.tsx

## References

- https://nextjs.org/docs/messages/missing-data-scroll-behavior#why-this-warning-occurred

Assisted-by: Grok Build (xAI)