### PR TITLE
ci: add timeout-minutes to GitHub Actions jobs for runaway prevention

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   accessibility:
     runs-on: ubicloud-standard-2
+    timeout-minutes: 25
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   lighthouse:
     runs-on: ubicloud-standard-2
+    timeout-minutes: 25
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build:
     runs-on: ubicloud-standard-2
+    timeout-minutes: 30
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -29,6 +29,7 @@ jobs:
     name: Validate migrations locally
     if: github.event_name == 'pull_request'
     runs-on: ubicloud-standard-2
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -123,6 +124,7 @@ jobs:
     name: Apply migration to production
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubicloud-standard-2
+    timeout-minutes: 10
     environment: production
 
     steps:


### PR DESCRIPTION
## Summary

Add explicit `timeout-minutes` to **every job** in all GitHub Actions workflows. This is a runaway prevention (暴走対策) measure.

GitHub's default job timeout is 360 minutes (6 hours). We now cap each job at a reasonable duration based on what it actually does.

## Jobs updated

| Workflow                  | Job                     | timeout-minutes |
|---------------------------|-------------------------|-----------------|
| node.js.yml               | build                   | 30              |
| accessibility.yml         | accessibility           | 25              |
| lighthouse.yml            | lighthouse              | 25              |
| copilot-setup-steps.yml   | copilot-setup-steps     | 10              |
| supabase-migrate.yml      | check (PR validation)   | 20              |
| supabase-migrate.yml      | deploy (production)     | 10              |

## Rationale

- Playwright / Lighthouse / Supabase local start + tests can occasionally hang.
- Supabase migrations and production `db push` should be fast.
- Setup-only jobs are very quick.
- Values are intentionally generous to avoid flaky timeouts on slow CI runners while still providing strong protection.

## Verification

- Created feature branch first (`ci/add-job-timeouts`) before any edits (per [AGENTS.md](https://github.com/ykzts/ykzts/blob/main/AGENTS.md))
- `pnpm check` passed
- lefthook pre-commit / commit-msg / pre-push (typecheck) all green
- Commit follows Conventional Commits + AI assistance trailer

Assisted-by: Grok 4.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions ワークフローのタイムアウト設定を統一しました。複数の自動化タスク（ビルド、アクセシビリティチェック、パフォーマンス測定、データベース移行）に実行時間上限を設定し、CI/CD パイプラインの安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->