### PR TITLE
fix(portfolio): pin Playwright version in CI and align a11y tests with seed data

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -21,6 +21,8 @@ permissions:
 env:
   # renovate: datasource=node-version depName=node
   NODE_VERSION: 24.16.0
+  # renovate: datasource=npm depName=@playwright/test
+  PLAYWRIGHT_VERSION: 1.60.0
   # renovate: datasource=github-releases depName=supabase/cli
   SUPABASE_VERSION: 2.106.0
 
@@ -53,7 +55,7 @@ jobs:
           ANON_KEY=$(supabase status -o json | jq -r '.ANON_KEY')
           echo "SUPABASE_ANON_KEY=${ANON_KEY}" >> $GITHUB_OUTPUT
       - name: Install Playwright browsers
-        run: pnpm dlx playwright install --with-deps chromium
+        run: pnpm dlx playwright@${{ env.PLAYWRIGHT_VERSION }} install --with-deps chromium
       - name: Run accessibility tests
         run: pnpm test:a11y
         env:

--- a/apps/portfolio/e2e/accessibility/homepage.spec.ts
+++ b/apps/portfolio/e2e/accessibility/homepage.spec.ts
@@ -1,6 +1,9 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
+/** Profile name from supabase/seed.sql */
+const SEED_PROFILE_NAME = "田中 太郎";
+
 test.describe("Accessibility Tests", () => {
   test("homepage should not have any automatically detectable WCAG A/AA violations", async ({
     page,
@@ -39,7 +42,7 @@ test.describe("Accessibility Tests", () => {
     const h1Elements = page.locator("h1");
     await expect(h1Elements).toHaveCount(1);
     const h1Text = await h1Elements.first().textContent();
-    expect(h1Text).toContain("Test User");
+    expect(h1Text).toContain(SEED_PROFILE_NAME);
 
     // Should have h2 elements for sections
     const h2Elements = page.locator("h2");
@@ -57,7 +60,7 @@ test.describe("Accessibility Tests", () => {
     await expect(skipLink).toBeVisible();
 
     // Check social media links have proper aria-labels
-    const socialLinks = page.locator('[aria-label*="Test Userの"]');
+    const socialLinks = page.locator(`[aria-label*="${SEED_PROFILE_NAME}の"]`);
     const socialLinkCount = await socialLinks.count();
     expect(socialLinkCount).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

Accessibility Testing CI が落ちていた原因を修正します。

- **Playwright バージョン不整合**: `pnpm dlx playwright` が常に最新版（1.61.0 / browser revision 1228）のブラウザをインストールしていた一方、`@playwright/test` 1.60.0 は revision 1223 を要求しており、テストがブラウザ起動前に失敗していました。CI ワークフローで `PLAYWRIGHT_VERSION` を固定し、Renovate で `@playwright/test` と同期できるようにしました。
- **E2E テストと seed データの不整合**: #4045 で seed のプロフィール名が `田中 太郎` に変更された後も、`homepage.spec.ts` が `Test User` を期待し続けていたため、ブラウザ不整合を解消した後もテストが失敗する状態でした。seed データに合わせてアサーションを更新しました。

## Changes

- `.github/workflows/accessibility.yml`: `PLAYWRIGHT_VERSION: 1.60.0` を追加し、`pnpm dlx playwright@${{ env.PLAYWRIGHT_VERSION }} install` に変更
- `apps/portfolio/e2e/accessibility/homepage.spec.ts`: seed プロフィール名 `田中 太郎` を定数化し、見出し・aria-label の期待値を更新

## Test plan

- [ ] Accessibility Testing workflow が green になること
- [ ] 8 件の Playwright a11y テストがすべて pass すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * アクセシビリティテストを改善し、プロフィール情報の検証精度を向上

* **Chores**
  * テスト環境のブラウザインストールプロセスを最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->