### PR TITLE
build(deps): run TypeScript 6 and 7 side by side

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "EditorConfig.EditorConfig",
+    "TypeScriptTeam.native-preview",
     "biomejs.biome",
     "unifiedjs.vscode-mdx"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
   "editor.formatOnSave": true,
   "files.associations": {
     "*.css": "tailwindcss"
-  },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  }
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -25,11 +25,12 @@
   "description": "Admin application for content management",
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.2",
-    "@vercel/config": "0.5.5",
     "@tailwindcss/typography": "0.5.20",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
+    "@vercel/config": "0.5.5",
     "@ykzts/tsconfig": "workspace:*",
     "postcss": "8.5.16",
     "shadcn": "4.13.0",

--- a/apps/blog-legacy/package.json
+++ b/apps/blog-legacy/package.json
@@ -16,6 +16,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -25,7 +25,6 @@
   "description": "Next.js blog application for ykzts.blog",
   "devDependencies": {
     "@portabletext/types": "4.0.2",
-    "@vercel/config": "0.5.5",
     "@tailwindcss/postcss": "4.3.2",
     "@tailwindcss/typography": "0.5.20",
     "@testing-library/dom": "10.4.1",
@@ -35,6 +34,8 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
+    "@vercel/config": "0.5.5",
     "@vitejs/plugin-react": "6.0.3",
     "@ykzts/tsconfig": "workspace:*",
     "jsdom": "29.1.1",

--- a/apps/memo/package.json
+++ b/apps/memo/package.json
@@ -23,6 +23,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "postcss": "8.5.16",
     "tailwindcss": "4.3.2",

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -7,7 +7,6 @@
     "@vercel/analytics": "2.0.1",
     "@vercel/microfrontends": "2.4.0",
     "@ykzts/layout": "workspace:*",
-
     "@ykzts/site-config": "workspace:*",
     "@ykzts/supabase": "workspace:*",
     "@ykzts/ui": "workspace:*",
@@ -41,6 +40,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "6.0.3",
     "@ykzts/tsconfig": "workspace:*",
     "axe-core": "4.12.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "6.0.3",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -38,6 +38,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "6.0.3",
     "@ykzts/tsconfig": "workspace:*",
     "jsdom": "29.1.1",

--- a/packages/site-config/package.json
+++ b/packages/site-config/package.json
@@ -14,6 +14,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -11,6 +11,7 @@
   "description": "Supabase database type definitions for ykzts applications",
   "devDependencies": {
     "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:"
   },
@@ -54,7 +55,6 @@
       "types": "./src/auth.ts",
       "default": "./src/auth.ts"
     },
-
     "./proxy": {
       "types": "./src/proxy.ts",
       "default": "./src/proxy.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,6 @@
     "./blog-urls": "./src/blog-urls.ts",
     "./csp": "./src/csp.ts",
     "./security-headers": "./src/security-headers.ts",
-
     "./draft-preview": "./src/draft-preview.ts",
     "./secrets": "./src/secrets.ts",
     "./fediverse": "./src/fediverse/index.ts",
@@ -31,6 +30,7 @@
   "devDependencies": {
     "@portabletext/types": "4.0.2",
     "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@types/react-dom':
       specifier: 19.2.3
       version: 19.2.3
+    '@typescript/native':
+      specifier: npm:typescript@7.0.2
+      version: 7.0.2
     next:
       specifier: 16.3.0-preview.5
       version: 16.3.0-preview.5
@@ -28,8 +31,8 @@ catalogs:
       specifier: 19.2.7
       version: 19.2.7
     typescript:
-      specifier: 6.0.3
-      version: 6.0.3
+      specifier: npm:@typescript/typescript6@6.0.2
+      version: 6.0.2
     vitest:
       specifier: 4.1.10
       version: 4.1.10
@@ -43,7 +46,7 @@ importers:
         version: 2.5.3
       '@commitlint/cli':
         specifier: 21.2.1
-        version: 21.2.1(@types/node@26.0.0)(conventional-commits-parser@7.1.0)(typescript@6.0.3)
+        version: 21.2.1(@types/node@26.0.0)(conventional-commits-parser@7.1.0)(typescript@7.0.2)
       '@commitlint/config-conventional':
         specifier: 21.2.0
         version: 21.2.0
@@ -58,7 +61,7 @@ importers:
         version: 2.10.4
       ultracite:
         specifier: 7.9.3
-        version: 7.9.3(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 7.9.3(eslint@10.7.0(jiti@2.7.0))(typescript@7.0.2)
 
   apps/admin:
     dependencies:
@@ -138,6 +141,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@vercel/config':
         specifier: 0.5.5
         version: 0.5.5
@@ -149,7 +155,7 @@ importers:
         version: 8.5.16
       shadcn:
         specifier: 4.13.0
-        version: 4.13.0(typescript@6.0.3)
+        version: 4.13.0(@typescript/typescript6@6.0.2)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2
@@ -158,7 +164,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -256,6 +262,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@vercel/config':
         specifier: 0.5.5
         version: 0.5.5
@@ -273,7 +282,7 @@ importers:
         version: 8.5.16
       shadcn:
         specifier: 4.13.0
-        version: 4.13.0(typescript@6.0.3)
+        version: 4.13.0(@typescript/typescript6@6.0.2)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2
@@ -282,7 +291,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -314,12 +323,15 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -384,6 +396,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -398,7 +413,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   apps/portfolio:
     dependencies:
@@ -511,6 +526,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: 6.0.3
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -531,7 +549,7 @@ importers:
         version: 8.5.16
       shadcn:
         specifier: 4.13.0
-        version: 4.13.0(typescript@6.0.3)
+        version: 4.13.0(@typescript/typescript6@6.0.2)
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2
@@ -540,7 +558,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 8.1.4
         version: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
@@ -552,34 +570,34 @@ importers:
     dependencies:
       '@lexical/code':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@lexical/link':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@lexical/list':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@lexical/react':
         specifier: 0.47.0
-        version: 0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)
+        version: 0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.31)
       '@lexical/rich-text':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@lexical/selection':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@lexical/table':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@lexical/utils':
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       '@ykzts/ui':
         specifier: workspace:*
         version: link:../ui
       lexical:
         specifier: 0.47.0
-        version: 0.47.0(typescript@6.0.3)
+        version: 0.47.0(@typescript/typescript6@6.0.2)
       lucide-react:
         specifier: 1.24.0
         version: 1.24.0(react@19.2.7)
@@ -599,6 +617,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: 6.0.3
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@26.0.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -607,7 +628,7 @@ importers:
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.0.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -657,6 +678,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: 6.0.3
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -671,7 +695,7 @@ importers:
         version: 16.3.0-preview.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -681,12 +705,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -715,12 +742,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   packages/tsconfig: {}
 
@@ -760,12 +790,15 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
 
   packages/utils:
     dependencies:
@@ -794,12 +827,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      '@typescript/native':
+        specifier: 'catalog:'
+        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -2919,6 +2955,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.63.0':
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -6785,6 +6945,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -7894,12 +8059,12 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@commitlint/cli@21.2.1(@types/node@26.0.0)(conventional-commits-parser@7.1.0)(typescript@6.0.3)':
+  '@commitlint/cli@21.2.1(@types/node@26.0.0)(conventional-commits-parser@7.1.0)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-conventional': 21.2.0
       '@commitlint/format': 21.2.0
       '@commitlint/lint': 21.2.0
-      '@commitlint/load': 21.2.0(@types/node@26.0.0)(typescript@6.0.3)
+      '@commitlint/load': 21.2.0(@types/node@26.0.0)(typescript@7.0.2)
       '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.0)
       '@commitlint/types': 21.2.0
       tinyexec: 1.2.4
@@ -7944,14 +8109,14 @@ snapshots:
       '@commitlint/rules': 21.2.0
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.0(@types/node@26.0.0)(typescript@6.0.3)':
+  '@commitlint/load@21.2.0(@types/node@26.0.0)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.2.0
       '@commitlint/types': 21.2.0
-      cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.0.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.0.0)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2)
       es-toolkit: 1.48.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -8343,253 +8508,253 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lexical/a11y@0.47.0(typescript@6.0.3)':
+  '@lexical/a11y@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/clipboard@0.47.0(typescript@6.0.3)':
+  '@lexical/clipboard@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/list': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/list': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
       '@types/trusted-types': 2.0.7
-      lexical: 0.47.0(typescript@6.0.3)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/code-core@0.47.0(typescript@6.0.3)':
+  '@lexical/code-core@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/code-prism@0.47.0(typescript@6.0.3)':
+  '@lexical/code-prism@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/code-core': 0.47.0(typescript@6.0.3)
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/code-core': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
       prismjs: 1.30.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/code@0.47.0(typescript@6.0.3)':
+  '@lexical/code@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/code-core': 0.47.0(typescript@6.0.3)
-      '@lexical/code-prism': 0.47.0(typescript@6.0.3)
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/code-core': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/code-prism': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/devtools-core@0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+  '@lexical/devtools-core@0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/link': 0.47.0(typescript@6.0.3)
-      '@lexical/mark': 0.47.0(typescript@6.0.3)
-      '@lexical/table': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/link': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/mark': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/table': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/dragon@0.47.0(typescript@6.0.3)':
+  '@lexical/dragon@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/extension@0.47.0(typescript@6.0.3)':
+  '@lexical/extension@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
       '@preact/signals-core': 1.14.3
-      lexical: 0.47.0(typescript@6.0.3)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/hashtag@0.47.0(typescript@6.0.3)':
+  '@lexical/hashtag@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/text': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/text': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/history@0.47.0(typescript@6.0.3)':
+  '@lexical/history@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/html@0.47.0(typescript@6.0.3)':
+  '@lexical/html@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/internal@0.47.0(typescript@6.0.3)':
+  '@lexical/internal@0.47.0(@typescript/typescript6@6.0.2)':
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/link@0.47.0(typescript@6.0.3)':
+  '@lexical/link@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/list@0.47.0(typescript@6.0.3)':
+  '@lexical/list@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/mark@0.47.0(typescript@6.0.3)':
+  '@lexical/mark@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/markdown@0.47.0(typescript@6.0.3)':
+  '@lexical/markdown@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/code-core': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/link': 0.47.0(typescript@6.0.3)
-      '@lexical/list': 0.47.0(typescript@6.0.3)
-      '@lexical/rich-text': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      '@lexical/text': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/code-core': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/link': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/list': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/rich-text': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/text': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/overflow@0.47.0(typescript@6.0.3)':
+  '@lexical/overflow@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      lexical: 0.47.0(typescript@6.0.3)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/plain-text@0.47.0(typescript@6.0.3)':
+  '@lexical/plain-text@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.47.0(typescript@6.0.3)
-      '@lexical/dragon': 0.47.0(typescript@6.0.3)
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/clipboard': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/dragon': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/react@0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)':
+  '@lexical/react@0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.31)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@lexical/a11y': 0.47.0(typescript@6.0.3)
-      '@lexical/devtools-core': 0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@lexical/dragon': 0.47.0(typescript@6.0.3)
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/hashtag': 0.47.0(typescript@6.0.3)
-      '@lexical/history': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/link': 0.47.0(typescript@6.0.3)
-      '@lexical/list': 0.47.0(typescript@6.0.3)
-      '@lexical/mark': 0.47.0(typescript@6.0.3)
-      '@lexical/markdown': 0.47.0(typescript@6.0.3)
-      '@lexical/overflow': 0.47.0(typescript@6.0.3)
-      '@lexical/plain-text': 0.47.0(typescript@6.0.3)
-      '@lexical/rich-text': 0.47.0(typescript@6.0.3)
-      '@lexical/table': 0.47.0(typescript@6.0.3)
-      '@lexical/text': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      '@lexical/yjs': 0.47.0(typescript@6.0.3)(yjs@13.6.31)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/a11y': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/devtools-core': 0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@lexical/dragon': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/hashtag': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/history': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/link': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/list': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/mark': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/markdown': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/overflow': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/plain-text': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/rich-text': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/table': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/text': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/yjs': 0.47.0(@typescript/typescript6@6.0.2)(yjs@13.6.31)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
       yjs: 13.6.31
 
-  '@lexical/rich-text@0.47.0(typescript@6.0.3)':
+  '@lexical/rich-text@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.47.0(typescript@6.0.3)
-      '@lexical/dragon': 0.47.0(typescript@6.0.3)
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/clipboard': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/dragon': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/selection@0.47.0(typescript@6.0.3)':
+  '@lexical/selection@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/table@0.47.0(typescript@6.0.3)':
+  '@lexical/table@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.47.0(typescript@6.0.3)
-      '@lexical/extension': 0.47.0(typescript@6.0.3)
-      '@lexical/html': 0.47.0(typescript@6.0.3)
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/utils': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/clipboard': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/text@0.47.0(typescript@6.0.3)':
+  '@lexical/text@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/utils@0.47.0(typescript@6.0.3)':
+  '@lexical/utils@0.47.0(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@lexical/yjs@0.47.0(typescript@6.0.3)(yjs@13.6.31)':
+  '@lexical/yjs@0.47.0(@typescript/typescript6@6.0.2)(yjs@13.6.31)':
     dependencies:
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
-      '@lexical/selection': 0.47.0(typescript@6.0.3)
-      lexical: 0.47.0(typescript@6.0.3)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(@typescript/typescript6@6.0.2)
       yjs: 13.6.31
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   '@lhci/cli@0.15.1':
     dependencies:
@@ -9613,12 +9778,12 @@ snapshots:
       '@types/node': 26.0.0
     optional: true
 
-  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.63.0(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.63.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9627,35 +9792,35 @@ snapshots:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
 
-  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@7.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@7.0.2)
       eslint: 10.7.0(jiti@2.7.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9663,6 +9828,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -10391,21 +10620,30 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.0.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.0.0)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2):
     dependencies:
       '@types/node': 26.0.0
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.6.1
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
+  cosmiconfig@9.0.2(@typescript/typescript6@6.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
+
+  cosmiconfig@9.0.2(typescript@7.0.2):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 7.0.2
 
   croner@10.0.1: {}
 
@@ -11861,11 +12099,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lexical@0.47.0(typescript@6.0.3):
+  lexical@0.47.0(@typescript/typescript6@6.0.2):
     dependencies:
-      '@lexical/internal': 0.47.0(typescript@6.0.3)
+      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   lib0@0.2.117:
     dependencies:
@@ -13630,7 +13868,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.13.0(typescript@6.0.3):
+  shadcn@4.13.0(@typescript/typescript6@6.0.2):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
@@ -13641,7 +13879,7 @@ snapshots:
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.2
       commander: 14.0.3
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.2)
       dedent: 1.7.2
       deepmerge: 4.3.1
       diff: 8.0.4
@@ -14068,9 +14306,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(typescript@7.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   ts-morph@26.0.0:
     dependencies:
@@ -14141,6 +14379,29 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+
   uc.micro@2.1.0: {}
 
   uglify-js@3.19.3:
@@ -14148,10 +14409,10 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
-  ultracite@7.9.3(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3):
+  ultracite@7.9.3(eslint@10.7.0(jiti@2.7.0))(typescript@7.0.2):
     dependencies:
       '@clack/prompts': 1.6.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@7.0.2)
       commander: 15.0.0
       cross-spawn: 7.0.6
       deepmerge: 4.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,13 +6,19 @@ packages:
 
 catalog:
   '@next/mdx': 16.3.0-preview.5
+  # TypeScript 7 (native) CLI as tsc; installed as @typescript/native to avoid
+  # conflicting with the TypeScript 6 API package below.
+  # See https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0
+  '@typescript/native': npm:typescript@7.0.2
   '@types/node': 24.13.3
   '@types/react': 19.2.17
   '@types/react-dom': 19.2.3
   next: 16.3.0-preview.5
   react: 19.2.7
   react-dom: 19.2.7
-  typescript: 6.0.3
+  # TypeScript 6 API + tsc6 binary (for tools that still need the classic API,
+  # e.g. typescript-eslint). Alias keeps the import name `typescript`.
+  typescript: npm:@typescript/typescript6@6.0.2
   vitest: 4.1.10
 
 allowBuilds:


### PR DESCRIPTION
## Summary

- TypeScript 7 を `@typescript/native`（`npm:typescript@7`）として導入し、`tsc` / `pnpm typecheck` を TS 7 に切り替え
- `typescript` パッケージは `@typescript/typescript6` エイリアスとし、classic API（`require('typescript')`）と `tsc6` を維持
- VS Code 向けに TypeScript 7 language server 拡張（`TypeScriptTeam.native-preview`）を推奨。薄い互換パッケージにはフル `tsserver` が無いため、壊れていた `typescript.tsdk` 設定を削除

[TypeScript 7 の side-by-side 手順](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0) に従い、TS 7 がまだ安定 API を出荷しない間もツール互換を保てるようにしています。Renovate の単純な major 更新（#4115）では API 非互換の可能性があるため、こちらで置き換えます。

Close #4115

## Changes

| Area | Change |
|------|--------|
| `pnpm-workspace.yaml` catalog | `typescript` → `npm:@typescript/typescript6@6.0.2`、`@typescript/native` → `npm:typescript@7.0.2` |
| apps / packages | typecheck 対象パッケージに `@typescript/native: catalog:` を追加 |
| `.vscode` | native-preview 拡張を recommendations に追加、`typescript.tsdk` を削除 |

## Test plan

- [x] `pnpm install` が成功する
- [x] `tsc --version` が 7.0.2、`tsc6 --version` と `require('typescript').version` が 6.x
- [x] `pnpm typecheck` が全パッケージで成功する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **開発環境**
  - TypeScriptの新しい実行環境を各アプリ・パッケージで利用できるようになりました。
  - 従来のTypeScript環境も継続利用できる構成に整理しました。
- **設定**
  - エディターで推奨される拡張機能を追加しました。
  - TypeScript SDKの個別指定を見直し、設定を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->