### PR TITLE
refactor: grow Cache Components static shells, drop coarse Suspense

### DIFF
--- a/apps/admin/app/(authenticated)/key-visual/page.tsx
+++ b/apps/admin/app/(authenticated)/key-visual/page.tsx
@@ -16,9 +16,20 @@ export default function KeyVisualPage() {
       <Panel>
         <Suspense
           fallback={
-            <div className="animate-pulse space-y-4">
-              <div className="aspect-video w-full max-w-sm rounded-lg border-2 border-border bg-muted/10" />
-              <div className="h-32 w-full rounded-lg border-2 border-border border-dashed bg-muted/10" />
+            <div
+              aria-label="読み込み中..."
+              aria-live="polite"
+              className="space-y-4"
+              role="status"
+            >
+              <div
+                aria-hidden="true"
+                className="aspect-video w-full max-w-sm animate-pulse rounded-lg border-2 border-border bg-muted"
+              />
+              <div
+                aria-hidden="true"
+                className="h-32 w-full animate-pulse rounded-lg border-2 border-border border-dashed bg-muted"
+              />
             </div>
           }
         >

--- a/apps/admin/app/(authenticated)/layout.tsx
+++ b/apps/admin/app/(authenticated)/layout.tsx
@@ -1,4 +1,3 @@
-import { getCurrentUser } from "@ykzts/supabase/auth";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,7 +8,6 @@ import {
 import { User as UserIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { getProfile } from "@/lib/data";
 import { logout } from "../login/actions";
@@ -63,16 +61,18 @@ function UserInfoFallback() {
   );
 }
 
-async function AuthGuard({ children }: { children: React.ReactNode }) {
-  // Auth guard wrapped in Suspense - checks auth and redirects if needed
-  const user = await getCurrentUser();
-
-  if (!user) {
-    redirect("/login");
-  }
-
+/**
+ * Auth is enforced in proxy.ts (session refresh + redirect). The layout shell
+ * (header, nav, main frame) is static; only the user avatar menu streams from
+ * private cache.
+ */
+export default function AuthenticatedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
-    <>
+    <div className="min-h-screen bg-background">
       <header className="border-border border-b bg-card">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">
@@ -91,18 +91,6 @@ async function AuthGuard({ children }: { children: React.ReactNode }) {
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {children}
       </main>
-    </>
-  );
-}
-
-function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="min-h-screen bg-background">
-      <Suspense fallback={<div className="min-h-screen bg-background" />}>
-        <AuthGuard>{children}</AuthGuard>
-      </Suspense>
     </div>
   );
 }
-
-export default AuthenticatedLayout;

--- a/apps/admin/app/(authenticated)/posts/[id]/_components/post-form-skeleton.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/_components/post-form-skeleton.tsx
@@ -1,63 +1,115 @@
 export function PostFormSkeleton() {
   return (
-    <div className="animate-pulse space-y-6">
-      {/* Two-column layout skeleton */}
+    <div
+      aria-label="読み込み中..."
+      aria-live="polite"
+      className="space-y-6"
+      role="status"
+    >
+      {/* Two-column layout skeleton matching PostForm */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_380px]">
         {/* Left Column - Main Content */}
         <div className="space-y-6">
-          {/* Title */}
           <div>
-            <div className="mb-2 h-5 w-20 rounded bg-muted/20" />
-            <div className="h-10 w-full rounded bg-muted/20" />
-            <div className="mt-1 h-4 w-32 rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mb-2 h-5 w-20 animate-pulse rounded bg-muted"
+            />
+            <div
+              aria-hidden="true"
+              className="h-10 w-full animate-pulse rounded bg-muted"
+            />
+            <div
+              aria-hidden="true"
+              className="mt-1 h-4 w-32 animate-pulse rounded bg-muted"
+            />
           </div>
 
-          {/* Content Editor */}
           <div>
-            <div className="mb-2 h-5 w-24 rounded bg-muted/20" />
-            <div className="h-96 w-full rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mb-2 h-5 w-24 animate-pulse rounded bg-muted"
+            />
+            <div
+              aria-hidden="true"
+              className="h-96 w-full animate-pulse rounded bg-muted"
+            />
           </div>
         </div>
 
         {/* Right Column - Metadata Sidebar */}
         <div className="space-y-6">
-          {/* Slug */}
           <div>
-            <div className="mb-2 h-5 w-16 rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mb-2 h-5 w-16 animate-pulse rounded bg-muted"
+            />
             <div className="flex gap-2">
-              <div className="h-10 flex-1 rounded bg-muted/20" />
-              <div className="h-10 w-24 rounded bg-muted/20" />
+              <div
+                aria-hidden="true"
+                className="h-10 flex-1 animate-pulse rounded bg-muted"
+              />
+              <div
+                aria-hidden="true"
+                className="h-10 w-24 animate-pulse rounded bg-muted"
+              />
             </div>
-            <div className="mt-1 h-4 w-48 rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mt-1 h-4 w-48 animate-pulse rounded bg-muted"
+            />
           </div>
 
-          {/* Excerpt */}
           <div>
-            <div className="mb-2 h-5 w-12 rounded bg-muted/20" />
-            <div className="h-24 w-full rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mb-2 h-5 w-12 animate-pulse rounded bg-muted"
+            />
+            <div
+              aria-hidden="true"
+              className="h-24 w-full animate-pulse rounded bg-muted"
+            />
           </div>
 
-          {/* Tags */}
           <div>
-            <div className="mb-2 h-5 w-10 rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mb-2 h-5 w-10 animate-pulse rounded bg-muted"
+            />
             <div className="flex gap-2">
-              <div className="h-10 flex-1 rounded bg-muted/20" />
-              <div className="h-10 w-16 rounded bg-muted/20" />
+              <div
+                aria-hidden="true"
+                className="h-10 flex-1 animate-pulse rounded bg-muted"
+              />
+              <div
+                aria-hidden="true"
+                className="h-10 w-16 animate-pulse rounded bg-muted"
+              />
             </div>
           </div>
 
-          {/* Status */}
           <div>
-            <div className="mb-2 h-5 w-20 rounded bg-muted/20" />
-            <div className="h-10 w-full rounded bg-muted/20" />
+            <div
+              aria-hidden="true"
+              className="mb-2 h-5 w-20 animate-pulse rounded bg-muted"
+            />
+            <div
+              aria-hidden="true"
+              className="h-10 w-full animate-pulse rounded bg-muted"
+            />
           </div>
         </div>
       </div>
 
-      {/* Action Buttons */}
       <div className="flex justify-end gap-2">
-        <div className="h-10 w-24 rounded bg-muted/20" />
-        <div className="h-10 w-20 rounded bg-muted/20" />
+        <div
+          aria-hidden="true"
+          className="h-10 w-24 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-20 animate-pulse rounded bg-muted"
+        />
       </div>
     </div>
   );

--- a/apps/admin/app/(authenticated)/posts/[id]/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/page.tsx
@@ -12,7 +12,12 @@ export function generateStaticParams() {
   return [{ id: "_" }];
 }
 
-async function PostEditContent({ id }: { id: string }) {
+async function PostEditContent({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
   const post = await getPostById(id);
 
   if (!post) {
@@ -38,13 +43,11 @@ async function PostEditContent({ id }: { id: string }) {
   );
 }
 
-export default async function EditPostPage({
+export default function EditPostPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-
   return (
     <div>
       <h1 className="mb-6 font-bold text-3xl">投稿編集</h1>
@@ -55,7 +58,7 @@ export default async function EditPostPage({
           </Panel>
         }
       >
-        <PostEditContent id={id} />
+        <PostEditContent params={params} />
       </Suspense>
     </div>
   );

--- a/apps/admin/app/(authenticated)/posts/[id]/versions/[versionId]/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/versions/[versionId]/page.tsx
@@ -141,18 +141,25 @@ async function VersionDetailContent({
   );
 }
 
-export default async function VersionDetailPage({
+async function VersionDetailFromParams({
   params,
 }: {
   params: Promise<{ id: string; versionId: string }>;
 }) {
   const { id, versionId } = await params;
+  return <VersionDetailContent postId={id} versionId={versionId} />;
+}
 
+export default function VersionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; versionId: string }>;
+}) {
   return (
     <div>
       <h1 className="mb-6 font-bold text-3xl">バージョン詳細</h1>
       <Suspense fallback={<VersionDetailSkeleton />}>
-        <VersionDetailContent postId={id} versionId={versionId} />
+        <VersionDetailFromParams params={params} />
       </Suspense>
     </div>
   );

--- a/apps/admin/app/(authenticated)/posts/[id]/versions/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/[id]/versions/page.tsx
@@ -145,18 +145,25 @@ async function VersionsContent({ postId }: { postId: string }) {
   );
 }
 
-export default async function VersionsPage({
+async function VersionsContentFromParams({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  return <VersionsContent postId={id} />;
+}
 
+export default function VersionsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   return (
     <div>
       <h1 className="mb-6 font-bold text-3xl">バージョン履歴</h1>
       <Suspense fallback={<VersionsSkeleton />}>
-        <VersionsContent postId={id} />
+        <VersionsContentFromParams params={params} />
       </Suspense>
     </div>
   );

--- a/apps/admin/app/(authenticated)/posts/page.tsx
+++ b/apps/admin/app/(authenticated)/posts/page.tsx
@@ -140,7 +140,13 @@ export default function PostsPage({
         <NewPostButton />
       </div>
 
-      <PostsFilters />
+      <Suspense
+        fallback={
+          <div className="mb-6 h-9 w-full max-w-md animate-pulse rounded bg-muted" />
+        }
+      >
+        <PostsFilters />
+      </Suspense>
 
       <Suspense fallback={<PostsSkeleton />}>
         <PostsContentAsync searchParams={searchParams} />

--- a/apps/admin/app/(authenticated)/profile/_components/skeleton.tsx
+++ b/apps/admin/app/(authenticated)/profile/_components/skeleton.tsx
@@ -1,50 +1,98 @@
 export default function ProfileEditSkeleton() {
   return (
-    <div className="animate-pulse space-y-6">
-      {/* Name field */}
+    <div
+      aria-label="読み込み中..."
+      aria-live="polite"
+      className="space-y-6"
+      role="status"
+    >
       <div>
-        <div className="mb-2 h-5 w-16 rounded bg-muted/20" />
-        <div className="h-10 w-full rounded-md border border-input bg-muted/10" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-16 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-full animate-pulse rounded-md bg-muted"
+        />
       </div>
 
-      {/* Tagline field */}
       <div>
-        <div className="mb-2 h-5 w-32 rounded bg-muted/20" />
-        <div className="h-10 w-full rounded-md border border-input bg-muted/10" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-32 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-full animate-pulse rounded-md bg-muted"
+        />
       </div>
 
-      {/* Email field */}
       <div>
-        <div className="mb-2 h-5 w-36 rounded bg-muted/20" />
-        <div className="h-10 w-full rounded-md border border-input bg-muted/10" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-36 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-full animate-pulse rounded-md bg-muted"
+        />
       </div>
 
-      {/* About field */}
       <div>
-        <div className="mb-2 h-5 w-20 rounded bg-muted/20" />
-        <div className="h-32 w-full rounded-md border border-input bg-muted/10" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-20 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-32 w-full animate-pulse rounded-md bg-muted"
+        />
       </div>
 
-      {/* Social links section */}
       <div>
         <div className="mb-3 flex items-center justify-between">
-          <div className="h-5 w-32 rounded bg-muted/20" />
-          <div className="h-8 w-16 rounded bg-muted/10" />
+          <div
+            aria-hidden="true"
+            className="h-5 w-32 animate-pulse rounded bg-muted"
+          />
+          <div
+            aria-hidden="true"
+            className="h-8 w-16 animate-pulse rounded bg-muted"
+          />
         </div>
+        <div
+          aria-hidden="true"
+          className="h-16 w-full animate-pulse rounded-md bg-muted"
+        />
       </div>
 
-      {/* Technologies section */}
       <div>
         <div className="mb-3 flex items-center justify-between">
-          <div className="h-5 w-24 rounded bg-muted/20" />
-          <div className="h-8 w-16 rounded bg-muted/10" />
+          <div
+            aria-hidden="true"
+            className="h-5 w-24 animate-pulse rounded bg-muted"
+          />
+          <div
+            aria-hidden="true"
+            className="h-8 w-16 animate-pulse rounded bg-muted"
+          />
         </div>
+        <div
+          aria-hidden="true"
+          className="h-16 w-full animate-pulse rounded-md bg-muted"
+        />
       </div>
 
-      {/* Buttons */}
       <div className="flex gap-4">
-        <div className="inline-flex h-10 w-20 cursor-default items-center justify-center gap-2 rounded-md bg-muted/10 px-4 py-2 font-medium text-sm" />
-        <div className="inline-flex h-10 w-24 cursor-default items-center justify-center gap-2 rounded-md bg-muted/10 px-4 py-2 font-medium text-sm" />
+        <div
+          aria-hidden="true"
+          className="h-10 w-20 animate-pulse rounded-md bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-24 animate-pulse rounded-md bg-muted"
+        />
       </div>
     </div>
   );

--- a/apps/admin/app/(authenticated)/works/[id]/page.tsx
+++ b/apps/admin/app/(authenticated)/works/[id]/page.tsx
@@ -11,7 +11,12 @@ export function generateStaticParams() {
   return [{ id: "_" }];
 }
 
-async function WorkEditContent({ id }: { id: string }) {
+async function WorkEditContent({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
   const [work, allTechnologies] = await Promise.all([
     getWork(id),
     getAllTechnologies(),
@@ -33,13 +38,11 @@ async function WorkEditContent({ id }: { id: string }) {
   );
 }
 
-export default async function EditWorkPage({
+export default function EditWorkPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-
   return (
     <div>
       <h1 className="mb-6 font-bold text-3xl">作品編集</h1>
@@ -50,7 +53,7 @@ export default async function EditWorkPage({
           </Panel>
         }
       >
-        <WorkEditContent id={id} />
+        <WorkEditContent params={params} />
       </Suspense>
     </div>
   );

--- a/apps/admin/app/(authenticated)/works/_components/work-form-skeleton.tsx
+++ b/apps/admin/app/(authenticated)/works/_components/work-form-skeleton.tsx
@@ -1,32 +1,76 @@
 export function WorkFormSkeleton() {
   return (
-    <div className="animate-pulse space-y-6">
+    <div
+      aria-label="読み込み中..."
+      aria-live="polite"
+      className="space-y-6"
+      role="status"
+    >
       <div>
-        <div className="mb-2 h-5 w-20 rounded bg-muted/20" />
-        <div className="h-10 w-full rounded bg-muted/20" />
-        <div className="mt-1 h-4 w-32 rounded bg-muted/20" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-20 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-full animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="mt-1 h-4 w-32 animate-pulse rounded bg-muted"
+        />
       </div>
 
       <div>
-        <div className="mb-2 h-5 w-20 rounded bg-muted/20" />
-        <div className="h-10 w-full rounded bg-muted/20" />
-        <div className="mt-1 h-4 w-64 rounded bg-muted/20" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-20 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-full animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="mt-1 h-4 w-64 animate-pulse rounded bg-muted"
+        />
       </div>
 
       <div>
-        <div className="mb-2 h-5 w-20 rounded bg-muted/20" />
-        <div className="h-10 w-full rounded bg-muted/20" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-20 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-full animate-pulse rounded bg-muted"
+        />
       </div>
 
       <div>
-        <div className="mb-2 h-5 w-32 rounded bg-muted/20" />
-        <div className="h-[300px] w-full rounded bg-muted/20" />
-        <div className="mt-1 h-4 w-96 rounded bg-muted/20" />
+        <div
+          aria-hidden="true"
+          className="mb-2 h-5 w-32 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-[300px] w-full animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="mt-1 h-4 w-96 max-w-full animate-pulse rounded bg-muted"
+        />
       </div>
 
       <div className="flex justify-between gap-4">
-        <div className="h-10 w-20 rounded bg-muted/20" />
-        <div className="h-10 w-20 rounded bg-muted/20" />
+        <div
+          aria-hidden="true"
+          className="h-10 w-20 animate-pulse rounded bg-muted"
+        />
+        <div
+          aria-hidden="true"
+          className="h-10 w-20 animate-pulse rounded bg-muted"
+        />
       </div>
     </div>
   );

--- a/apps/admin/app/(authenticated)/works/new/page.tsx
+++ b/apps/admin/app/(authenticated)/works/new/page.tsx
@@ -1,16 +1,26 @@
+import { Suspense } from "react";
 import { Panel } from "@/components/panel";
 import { getAllTechnologies } from "@/lib/data";
 import { WorkForm } from "../_components/work-form";
+import { WorkFormSkeleton } from "../_components/work-form-skeleton";
 import { createWork } from "./actions";
 
-export default async function NewWorkPage() {
+async function NewWorkForm() {
   const allTechnologies = await getAllTechnologies();
 
+  return (
+    <WorkForm allTechnologies={allTechnologies} createAction={createWork} />
+  );
+}
+
+export default function NewWorkPage() {
   return (
     <div>
       <h1 className="mb-6 font-bold text-3xl">作品新規作成</h1>
       <Panel>
-        <WorkForm allTechnologies={allTechnologies} createAction={createWork} />
+        <Suspense fallback={<WorkFormSkeleton />}>
+          <NewWorkForm />
+        </Suspense>
       </Panel>
     </div>
   );

--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
@@ -13,11 +13,9 @@ import { getPostUrl } from "@ykzts/utils/blog-urls";
 import { isPortableTextValue } from "@ykzts/utils/portable-text";
 import type { Metadata, Route } from "next";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 import ArticleContent from "@/components/article-content";
 import PostNavigation from "@/components/post-navigation";
 import SimilarPosts from "@/components/similar-posts";
-import SimilarPostsSkeleton from "@/components/similar-posts-skeleton";
 import TableOfContents from "@/components/table-of-contents";
 import { DEFAULT_POST_TITLE } from "@/lib/constants";
 import { extractHeadings } from "@/lib/extract-headings";
@@ -289,9 +287,7 @@ export default async function PostDetailPage({ params }: PageProps) {
         {/* Full width: related articles */}
         <div className="mx-auto max-w-4xl">
           <div aria-atomic="false" aria-live="polite">
-            <Suspense fallback={<SimilarPostsSkeleton />}>
-              <SimilarPostsSection postId={post.id} />
-            </Suspense>
+            <SimilarPostsSection postId={post.id} />
           </div>
         </div>
       </main>

--- a/apps/blog/app/blog/draft/[slug]/page.tsx
+++ b/apps/blog/app/blog/draft/[slug]/page.tsx
@@ -7,7 +7,6 @@ import ArticleContent from "@/components/article-content";
 import DraftModeBanner from "@/components/draft-mode-banner";
 import PostNavigation from "@/components/post-navigation";
 import SimilarPosts from "@/components/similar-posts";
-import SimilarPostsSkeleton from "@/components/similar-posts-skeleton";
 import TableOfContents from "@/components/table-of-contents";
 import { DEFAULT_POST_TITLE } from "@/lib/constants";
 import { extractHeadings } from "@/lib/extract-headings";
@@ -65,7 +64,23 @@ export async function generateMetadata({
   };
 }
 
-export default async function DraftPostPage({ params }: PageProps) {
+function DraftPostSkeleton() {
+  return (
+    <main className="px-6 py-8 md:px-12 lg:px-24">
+      <div className="mx-auto max-w-4xl space-y-6">
+        <div className="h-8 w-2/3 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-1/4 animate-pulse rounded bg-muted" />
+        <div className="space-y-3 pt-4">
+          <div className="h-4 w-full animate-pulse rounded bg-muted" />
+          <div className="h-4 w-full animate-pulse rounded bg-muted" />
+          <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+    </main>
+  );
+}
+
+async function DraftPostContent({ params }: PageProps) {
   const { slug } = await params;
 
   if (slug === "_placeholder") {
@@ -143,12 +158,18 @@ export default async function DraftPostPage({ params }: PageProps) {
 
       <div className="mx-auto max-w-4xl">
         <div aria-atomic="false" aria-live="polite">
-          <Suspense fallback={<SimilarPostsSkeleton />}>
-            <SimilarPostsSection postId={post.id} />
-          </Suspense>
+          <SimilarPostsSection postId={post.id} />
         </div>
       </div>
     </main>
+  );
+}
+
+export default function DraftPostPage({ params }: PageProps) {
+  return (
+    <Suspense fallback={<DraftPostSkeleton />}>
+      <DraftPostContent params={params} />
+    </Suspense>
   );
 }
 

--- a/apps/blog/app/blog/page.tsx
+++ b/apps/blog/app/blog/page.tsx
@@ -2,10 +2,9 @@ import { getSiteName } from "@ykzts/site-config";
 import { getProfile } from "@ykzts/supabase/queries";
 import { Rss } from "lucide-react";
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import { YearArchiveLinks } from "./_components/archive-links";
 import { Pagination } from "./_components/pagination";
-import { Posts, PostsSkeleton } from "./_components/posts";
+import { Posts } from "./_components/posts";
 
 const siteName = getSiteName();
 
@@ -61,23 +60,9 @@ export default function HomePage() {
             <span>Atom</span>
           </a>
         </div>
-        <Suspense fallback={<PostsSkeleton count={5} />}>
-          <Posts />
-        </Suspense>
-
-        <Suspense
-          fallback={
-            <div className="mt-8 border-t pt-4">
-              <div className="h-4 w-48 animate-pulse rounded bg-muted" />
-            </div>
-          }
-        >
-          <YearArchiveLinks />
-        </Suspense>
-
-        <Suspense fallback={null}>
-          <Pagination />
-        </Suspense>
+        <Posts />
+        <YearArchiveLinks />
+        <Pagination />
       </div>
     </main>
   );

--- a/apps/blog/components/portable-text.tsx
+++ b/apps/blog/components/portable-text.tsx
@@ -10,19 +10,38 @@ import type {
   PortableTextValue,
 } from "@ykzts/utils/portable-text";
 import Image from "next/image";
-import { type ComponentProps, Suspense } from "react";
+import type { ComponentProps } from "react";
 import Link from "@/components/link";
 import { generateHeadingId } from "@/lib/extract-headings";
 import { highlightCode } from "@/lib/shiki";
 
-// Component to handle code block syntax highlighting
-async function CodeBlockHighlighter({
-  language,
-  text,
-}: {
-  language?: string;
-  text: string;
-}) {
+// Helper function to extract text from block children
+function extractTextFromBlock(children: unknown): string {
+  if (!Array.isArray(children)) {
+    return "";
+  }
+
+  return children
+    .map((child) => {
+      if (typeof child === "object" && child !== null && "text" in child) {
+        return String(child.text);
+      }
+      return "";
+    })
+    .join("");
+}
+
+// Named component for code blocks — highlightCode is "use cache", so it joins the static shell.
+const CodeBlockComponent: PortableTextBlockComponent = async (props) => {
+  // Extract text from the block's children spans
+  const text = extractTextFromBlock(props.value.children);
+
+  // Extract language if available
+  const language =
+    "language" in props.value && typeof props.value.language === "string"
+      ? props.value.language
+      : undefined;
+
   let html: string | null = null;
   try {
     html = await highlightCode(text, language);
@@ -43,49 +62,9 @@ async function CodeBlockHighlighter({
       <code>{text}</code>
     </pre>
   );
-}
-
-// Helper function to extract text from block children
-function extractTextFromBlock(children: unknown): string {
-  if (!Array.isArray(children)) {
-    return "";
-  }
-
-  return children
-    .map((child) => {
-      if (typeof child === "object" && child !== null && "text" in child) {
-        return String(child.text);
-      }
-      return "";
-    })
-    .join("");
-}
-
-// Named component for code blocks
-const CodeBlockComponent: PortableTextBlockComponent = (props) => {
-  // Extract text from the block's children spans
-  const text = extractTextFromBlock(props.value.children);
-
-  // Extract language if available
-  const language =
-    "language" in props.value && typeof props.value.language === "string"
-      ? props.value.language
-      : undefined;
-
-  return (
-    <Suspense
-      fallback={
-        <pre className="not-prose overflow-x-auto rounded-lg bg-muted p-4">
-          <code>{text}</code>
-        </pre>
-      }
-    >
-      <CodeBlockHighlighter language={language} text={text} />
-    </Suspense>
-  );
 };
 
-async function InlineCodeBlockHighlighter({
+async function InlineCodeBlock({
   code,
   language,
 }: {
@@ -134,17 +113,7 @@ const portableTextComponents = {
     code({ value }: { value: CodeBlock }) {
       const { code, language } = value;
 
-      return (
-        <Suspense
-          fallback={
-            <pre className="not-prose overflow-x-auto rounded-lg bg-muted p-4">
-              <code>{code}</code>
-            </pre>
-          }
-        >
-          <InlineCodeBlockHighlighter code={code} language={language} />
-        </Suspense>
-      );
+      return <InlineCodeBlock code={code} language={language} />;
     },
     image({ value }: { value: ImageBlock }) {
       const { alt, asset, height, width } = value;

--- a/apps/memo/app/[...path]/actions.ts
+++ b/apps/memo/app/[...path]/actions.ts
@@ -3,7 +3,7 @@
 import { checkAuth, getOwnerProfile } from "@ykzts/supabase/auth";
 import { createServerClient } from "@ykzts/supabase/server";
 import type { Json } from "@ykzts/supabase/types";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 
 export type UpdateMemoState = {
   error?: string;
@@ -101,6 +101,7 @@ export async function updateMemo(
   }
 
   revalidatePath(`/${memoPath}`);
+  revalidateTag("memos", "max");
 
   return { success: true };
 }

--- a/apps/memo/app/[...path]/page.tsx
+++ b/apps/memo/app/[...path]/page.tsx
@@ -4,6 +4,7 @@ import { createServerClient } from "@ykzts/supabase/server";
 import {
   extractFirstParagraph,
   isPortableTextValue,
+  type PortableTextValue,
 } from "@ykzts/utils/portable-text";
 import type { Metadata } from "next";
 import { draftMode } from "next/headers";
@@ -13,6 +14,7 @@ import { Suspense } from "react";
 import Header from "@/components/header";
 import { InlineMemoEditor } from "@/components/inline-memo-editor";
 import MemoPortableText from "@/components/portable-text";
+import { getPublicChildMemos, getPublicMemo } from "@/lib/memos";
 import { supabase as browserSupabase } from "@/lib/supabase/client";
 
 function isSupabaseConfigured() {
@@ -50,13 +52,8 @@ export async function generateStaticParams() {
     .select("path")
     .eq("visibility", "public");
 
-  if (error) {
-    throw new Error(
-      `Failed to fetch memos for static generation: ${error.message}`
-    );
-  }
-
-  if (memos.length === 0) {
+  // Build environments without live Supabase still need a valid sample path.
+  if (error || !memos || memos.length === 0) {
     return PLACEHOLDER_PARAMS;
   }
 
@@ -82,35 +79,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   const siteOrigin = getSiteOrigin();
-  const supabase = await createServerClient();
-
-  const { data: memo, error: memoError } = await supabase
-    .from("memos")
-    .select(
-      "path, visibility, published_at, updated_at, current_version:memo_versions!memos_current_version_id_fkey(id, title, content)"
-    )
-    .eq("path", memoPath)
-    .eq("visibility", "public")
-    .maybeSingle();
-
-  if (memoError) {
-    throw new Error(`Failed to fetch memo metadata: ${memoError.message}`);
-  }
+  // Public metadata uses the cookie-free cached path so it stays prerenderable.
+  const memo = await getPublicMemo(memoPath);
 
   if (!memo) {
-    // Check if there are child memos (index page)
-    const { data: children, error: childError } = await supabase
-      .from("memos")
-      .select("id")
-      .eq("visibility", "public")
-      .like("path", `${memoPath}/%`)
-      .limit(1);
+    const children = await getPublicChildMemos(memoPath);
 
-    if (childError) {
-      throw new Error(`Failed to fetch child memos: ${childError.message}`);
-    }
-
-    if (!children || children.length === 0) {
+    if (children.length === 0) {
       return { title: "Not Found" };
     }
 
@@ -143,25 +118,35 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-async function getMemo(memoPath: string, isDraftMode: boolean) {
-  if (!isSupabaseConfigured()) {
-    return { data: null, error: null };
-  }
+function MemoPageSkeleton() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6 space-y-3">
+          <div className="h-9 w-2/3 animate-pulse rounded bg-muted" />
+          <div className="h-4 w-1/3 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="space-y-3">
+          <div className="h-4 w-full animate-pulse rounded bg-muted" />
+          <div className="h-4 w-full animate-pulse rounded bg-muted" />
+          <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
+        </div>
+      </main>
+    </>
+  );
+}
 
+async function getOwnerMemo(memoPath: string) {
   const supabase = await createServerClient();
 
-  let query = supabase
+  const { data, error } = await supabase
     .from("memos")
     .select(
       "id, path, visibility, profile_id, published_at, updated_at, current_version:memo_versions!memos_current_version_id_fkey(id, title, content)"
     )
-    .eq("path", memoPath);
-
-  if (!isDraftMode) {
-    query = query.eq("visibility", "public");
-  }
-
-  const { data, error } = await query.maybeSingle();
+    .eq("path", memoPath)
+    .maybeSingle();
 
   if (error) {
     return { data: null, error };
@@ -170,14 +155,10 @@ async function getMemo(memoPath: string, isDraftMode: boolean) {
   return { data, error: null };
 }
 
-async function getChildMemos(pathPrefix: string, isDraftMode: boolean) {
-  if (!isSupabaseConfigured()) {
-    return { data: null, error: null };
-  }
-
+async function getOwnerChildMemos(pathPrefix: string) {
   const supabase = await createServerClient();
 
-  let query = supabase
+  const { data, error } = await supabase
     .from("memos")
     .select(
       "id, path, visibility, current_version:memo_versions!memos_current_version_id_fkey(id, title)"
@@ -185,12 +166,6 @@ async function getChildMemos(pathPrefix: string, isDraftMode: boolean) {
     .like("path", `${pathPrefix}/%`)
     .order("path", { ascending: true });
 
-  if (!isDraftMode) {
-    query = query.eq("visibility", "public");
-  }
-
-  const { data, error } = await query;
-
   if (error) {
     return { data: null, error };
   }
@@ -198,120 +173,41 @@ async function getChildMemos(pathPrefix: string, isDraftMode: boolean) {
   return { data, error: null };
 }
 
-async function MemoContent({ path: memoPath }: { path: string }) {
-  const [{ isEnabled: isDraftMode }, ownerProfile] = await Promise.all([
-    draftMode(),
-    getOwnerProfile(),
-  ]);
-
-  const { data: memo, error } = await getMemo(memoPath, isDraftMode);
-
-  if (error) {
-    return (
-      <>
-        <Header />
-        <main className="mx-auto max-w-3xl px-4 py-8">
-          <p className="text-muted-foreground">
-            メモの読み込みに失敗しました。
-          </p>
-        </main>
-      </>
-    );
-  }
-
-  if (!memo) {
-    // Check for child memos (index page)
-    const { data: children, error: childError } = await getChildMemos(
-      memoPath,
-      isDraftMode
-    );
-
-    if (childError) {
-      return (
-        <>
-          <Header />
-          <main className="mx-auto max-w-3xl px-4 py-8">
-            <p className="text-muted-foreground">
-              メモの読み込みに失敗しました。
-            </p>
-          </main>
-        </>
-      );
-    }
-
-    if (!children || children.length === 0) {
-      notFound();
-    }
-
-    const canEdit = Boolean(ownerProfile);
-
-    return (
-      <>
-        <Header canEdit={canEdit} />
-        <main className="mx-auto max-w-3xl px-4 py-8">
-          <h1 className="mb-2 font-bold text-3xl">
-            /{memoPath.split("/").at(-1) ?? memoPath}
-          </h1>
-          <p className="mb-6 text-muted-foreground text-sm">/{memoPath}</p>
-          <ul className="space-y-2">
-            {children.map((child) => {
-              const version = extractCurrentVersion(child.current_version);
-              const title = version?.title ?? child.path;
-              return (
-                <li key={child.id}>
-                  <Link
-                    className="flex items-center gap-2 rounded-md p-2 hover:bg-accent"
-                    href={`/${child.path}`}
-                  >
-                    <span className="flex-1 font-medium">{title}</span>
-                    <span className="text-muted-foreground text-sm">
-                      /{child.path}
-                    </span>
-                    {child.visibility === "private" && (
-                      <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
-                        非公開
-                      </span>
-                    )}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </main>
-      </>
-    );
-  }
-
-  // Edit permission: user must be authenticated and own the memo
-  const canEdit = Boolean(ownerProfile && memo.profile_id === ownerProfile.id);
-
-  const currentVersion = extractCurrentVersion(memo.current_version);
-  const title = currentVersion?.title ?? memo.path;
-  const content = isPortableTextValue(currentVersion?.content)
-    ? currentVersion.content
-    : null;
-
+function renderMemoView({
+  canEdit,
+  memo,
+  title,
+  content,
+}: {
+  canEdit: boolean;
+  memo: {
+    id: string;
+    path: string;
+    visibility: string;
+    published_at: string | null;
+    updated_at: string;
+  };
+  title: string;
+  content: PortableTextValue | null;
+}) {
   const dateOptions: Intl.DateTimeFormatOptions = { timeZone: "Asia/Tokyo" };
 
-  const getBody = () => {
-    if (canEdit) {
-      return (
-        <InlineMemoEditor
-          content={content}
-          memoId={memo.id}
-          memoPath={memo.path}
-          title={title}
-          visibility={memo.visibility}
-        />
-      );
-    }
-
-    if (content) {
-      return <MemoPortableText value={content} />;
-    }
-
-    return <p className="text-muted-foreground">コンテンツがありません。</p>;
-  };
+  let body: React.ReactNode;
+  if (canEdit) {
+    body = (
+      <InlineMemoEditor
+        content={content}
+        memoId={memo.id}
+        memoPath={memo.path}
+        title={title}
+        visibility={memo.visibility as "public" | "private"}
+      />
+    );
+  } else if (content) {
+    body = <MemoPortableText value={content} />;
+  } else {
+    body = <p className="text-muted-foreground">コンテンツがありません。</p>;
+  }
 
   return (
     <>
@@ -329,7 +225,7 @@ async function MemoContent({ path: memoPath }: { path: string }) {
           </div>
         </div>
 
-        {getBody()}
+        {body}
 
         <div className="mt-8 border-border border-t pt-4 text-muted-foreground text-sm">
           <p>
@@ -348,13 +244,179 @@ async function MemoContent({ path: memoPath }: { path: string }) {
   );
 }
 
+function renderIndexView({
+  canEdit,
+  memoPath,
+  children,
+}: {
+  canEdit: boolean;
+  memoPath: string;
+  children: Array<{
+    id: string;
+    path: string;
+    visibility: string;
+    current_version:
+      | { id: string; title: string | null }
+      | { id: string; title: string | null }[]
+      | null;
+  }>;
+}) {
+  return (
+    <>
+      <Header canEdit={canEdit} />
+      <main className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="mb-2 font-bold text-3xl">
+          /{memoPath.split("/").at(-1) ?? memoPath}
+        </h1>
+        <p className="mb-6 text-muted-foreground text-sm">/{memoPath}</p>
+        <ul className="space-y-2">
+          {children.map((child) => {
+            const version = extractCurrentVersion(child.current_version);
+            const title = version?.title ?? child.path;
+            return (
+              <li key={child.id}>
+                <Link
+                  className="flex items-center gap-2 rounded-md p-2 hover:bg-accent"
+                  href={`/${child.path}`}
+                >
+                  <span className="flex-1 font-medium">{title}</span>
+                  <span className="text-muted-foreground text-sm">
+                    /{child.path}
+                  </span>
+                  {child.visibility === "private" && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+                      非公開
+                    </span>
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </main>
+    </>
+  );
+}
+
+/**
+ * Public path: fully cached, no cookies.
+ */
+async function PublicMemoContent({ path: memoPath }: { path: string }) {
+  const memo = await getPublicMemo(memoPath);
+
+  if (!memo) {
+    const children = await getPublicChildMemos(memoPath);
+
+    if (children.length === 0) {
+      notFound();
+    }
+
+    return renderIndexView({
+      canEdit: false,
+      children,
+      memoPath,
+    });
+  }
+
+  const currentVersion = extractCurrentVersion(memo.current_version);
+  const title = currentVersion?.title ?? memo.path;
+  const content = isPortableTextValue(currentVersion?.content)
+    ? currentVersion.content
+    : null;
+
+  return renderMemoView({
+    canEdit: false,
+    content,
+    memo,
+    title,
+  });
+}
+
+/**
+ * Draft/owner path may include private memos and the inline editor.
+ * Public visitors fall through to the cached public tree.
+ */
+async function MemoContent({ path: memoPath }: { path: string }) {
+  const [{ isEnabled: isDraftMode }, ownerProfile] = await Promise.all([
+    draftMode(),
+    getOwnerProfile(),
+  ]);
+
+  if (!(isDraftMode && ownerProfile)) {
+    return <PublicMemoContent path={memoPath} />;
+  }
+
+  const { data: memo, error } = await getOwnerMemo(memoPath);
+
+  if (error) {
+    return (
+      <>
+        <Header />
+        <main className="mx-auto max-w-3xl px-4 py-8">
+          <p className="text-muted-foreground">
+            メモの読み込みに失敗しました。
+          </p>
+        </main>
+      </>
+    );
+  }
+
+  if (!memo) {
+    const { data: children, error: childError } =
+      await getOwnerChildMemos(memoPath);
+
+    if (childError) {
+      return (
+        <>
+          <Header />
+          <main className="mx-auto max-w-3xl px-4 py-8">
+            <p className="text-muted-foreground">
+              メモの読み込みに失敗しました。
+            </p>
+          </main>
+        </>
+      );
+    }
+
+    if (!children || children.length === 0) {
+      notFound();
+    }
+
+    return renderIndexView({
+      canEdit: true,
+      children,
+      memoPath,
+    });
+  }
+
+  const canEdit = memo.profile_id === ownerProfile.id;
+  const currentVersion = extractCurrentVersion(memo.current_version);
+  const title = currentVersion?.title ?? memo.path;
+  const content = isPortableTextValue(currentVersion?.content)
+    ? currentVersion.content
+    : null;
+
+  return renderMemoView({
+    canEdit,
+    content,
+    memo,
+    title,
+  });
+}
+
 export default async function MemoPage({ params }: Props) {
   const { path } = await params;
   const memoPath = path.join("/");
 
   return (
     <div className="min-h-screen bg-background">
-      <Suspense fallback={null}>
+      {/*
+        Suspense only for draftMode/owner reads. Fallback is content-shaped
+        (header chrome + skeleton), never a blank page. Public memo queries
+        use "use cache" so they resolve from the data cache after the runtime
+        check.
+      */}
+      <Suspense fallback={<MemoPageSkeleton />}>
         <MemoContent path={memoPath} />
       </Suspense>
     </div>

--- a/apps/memo/app/new/actions.ts
+++ b/apps/memo/app/new/actions.ts
@@ -3,7 +3,7 @@
 import { checkAuth, getOwnerProfile } from "@ykzts/supabase/auth";
 import { createServerClient } from "@ykzts/supabase/server";
 import type { Json } from "@ykzts/supabase/types";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { redirect } from "next/navigation";
 
 export type CreateMemoState = {
@@ -155,6 +155,7 @@ export async function createMemo(
 
   revalidatePath("/");
   revalidatePath(`/${normalizedPath}`);
+  revalidateTag("memos", "max");
 
   redirect(`/${normalizedPath}`);
 }

--- a/apps/memo/app/new/page.tsx
+++ b/apps/memo/app/new/page.tsx
@@ -4,6 +4,22 @@ import { Suspense } from "react";
 import Header from "@/components/header";
 import { NewMemoForm } from "@/components/new-memo-form";
 
+function NewMemoSkeleton() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="mb-6 font-bold text-2xl">新規メモ作成</h1>
+        <div className="space-y-4">
+          <div className="h-10 w-full animate-pulse rounded bg-muted" />
+          <div className="h-40 w-full animate-pulse rounded bg-muted" />
+          <div className="h-10 w-28 animate-pulse rounded bg-muted" />
+        </div>
+      </main>
+    </>
+  );
+}
+
 async function NewMemoContent() {
   const ownerProfile = await getOwnerProfile();
 
@@ -25,7 +41,7 @@ async function NewMemoContent() {
 export default function NewMemoPage() {
   return (
     <div className="min-h-screen bg-background">
-      <Suspense fallback={null}>
+      <Suspense fallback={<NewMemoSkeleton />}>
         <NewMemoContent />
       </Suspense>
     </div>

--- a/apps/memo/app/page.tsx
+++ b/apps/memo/app/page.tsx
@@ -4,107 +4,143 @@ import { draftMode } from "next/headers";
 import Link from "next/link";
 import { Suspense } from "react";
 import Header from "@/components/header";
+import { getPublicMemos } from "@/lib/memos";
 
-async function MemoList() {
-  const [{ isEnabled: isDraftMode }, ownerProfile, supabase] =
-    await Promise.all([draftMode(), getOwnerProfile(), createServerClient()]);
-
-  let query = supabase
-    .from("memos")
-    .select(
-      "id, path, visibility, published_at, updated_at, memo_versions(title)"
-    )
-    .order("updated_at", { ascending: false });
-
-  if (!(isDraftMode && ownerProfile)) {
-    // Public access: only show public memos
-    query = query.eq("visibility", "public");
-  }
-
-  const { data: memos, error } = await query;
-
-  if (error) {
-    return (
-      <p className="text-muted-foreground">メモの読み込みに失敗しました。</p>
-    );
-  }
-
-  if (!memos || memos.length === 0) {
+function MemoListItems({
+  memos,
+}: {
+  memos: Array<{
+    id: string;
+    path: string;
+    visibility: string;
+    title: string;
+  }>;
+}) {
+  if (memos.length === 0) {
     return <p className="text-muted-foreground">メモがありません。</p>;
   }
 
   return (
     <ul className="space-y-2">
-      {memos.map((memo) => {
-        const version = Array.isArray(memo.memo_versions)
-          ? memo.memo_versions[0]
-          : memo.memo_versions;
-        const title = version?.title ?? memo.path;
-        return (
-          <li key={memo.id}>
-            <Link
-              className="flex items-center gap-2 rounded-md p-2 hover:bg-accent"
-              href={`/${memo.path}`}
-            >
-              <span className="flex-1 font-medium">{title}</span>
-              {memo.visibility === "private" && (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
-                  非公開
-                </span>
-              )}
-            </Link>
-          </li>
-        );
-      })}
+      {memos.map((memo) => (
+        <li key={memo.id}>
+          <Link
+            className="flex items-center gap-2 rounded-md p-2 hover:bg-accent"
+            href={`/${memo.path}`}
+          >
+            <span className="flex-1 font-medium">{memo.title}</span>
+            {memo.visibility === "private" && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+                非公開
+              </span>
+            )}
+          </Link>
+        </li>
+      ))}
     </ul>
   );
 }
 
-async function MemoListHeader() {
-  const ownerProfile = await getOwnerProfile();
+function MemoListSkeleton() {
+  return (
+    <div className="space-y-2">
+      {["a", "b", "c"].map((key) => (
+        <div className="h-10 animate-pulse rounded-md bg-muted" key={key} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Prefer the public cached list (static shell path). Only when draft mode is
+ * enabled for the site owner do we hit the cookie-bound client for private rows.
+ */
+async function MemoList() {
+  const [{ isEnabled: isDraftMode }, ownerProfile] = await Promise.all([
+    draftMode(),
+    getOwnerProfile(),
+  ]);
+
+  if (isDraftMode && ownerProfile) {
+    const supabase = await createServerClient();
+    const { data: memos, error } = await supabase
+      .from("memos")
+      .select(
+        "id, path, visibility, published_at, updated_at, memo_versions(title)"
+      )
+      .order("updated_at", { ascending: false });
+
+    if (error) {
+      return (
+        <p className="text-muted-foreground">メモの読み込みに失敗しました。</p>
+      );
+    }
+
+    return (
+      <MemoListItems
+        memos={(memos ?? []).map((memo) => {
+          const version = Array.isArray(memo.memo_versions)
+            ? memo.memo_versions[0]
+            : memo.memo_versions;
+          return {
+            id: memo.id,
+            path: memo.path,
+            title: version?.title ?? memo.path,
+            visibility: memo.visibility,
+          };
+        })}
+      />
+    );
+  }
+
+  const memos = await getPublicMemos();
 
   return (
-    <div className="mb-6 flex items-center justify-between">
-      <h1 className="font-bold text-2xl">メモ一覧</h1>
-      {!!ownerProfile && (
-        <Link
-          className="rounded bg-primary px-3 py-1.5 text-primary-foreground text-sm hover:bg-primary/90"
-          href="/new"
-        >
-          新規作成
-        </Link>
-      )}
-    </div>
+    <MemoListItems
+      memos={memos.map((memo) => {
+        const version = Array.isArray(memo.memo_versions)
+          ? memo.memo_versions[0]
+          : memo.memo_versions;
+        return {
+          id: memo.id,
+          path: memo.path,
+          title: version?.title ?? memo.path,
+          visibility: memo.visibility,
+        };
+      })}
+    />
+  );
+}
+
+async function NewMemoButton() {
+  const ownerProfile = await getOwnerProfile();
+
+  if (!ownerProfile) {
+    return null;
+  }
+
+  return (
+    <Link
+      className="rounded bg-primary px-3 py-1.5 text-primary-foreground text-sm hover:bg-primary/90"
+      href="/new"
+    >
+      新規作成
+    </Link>
   );
 }
 
 export default function HomePage() {
   return (
     <div className="min-h-screen bg-background">
-      <Suspense fallback={null}>
-        <Header />
-      </Suspense>
+      <Header />
       <main className="mx-auto max-w-3xl px-4 py-8">
-        <Suspense
-          fallback={
-            <div className="mb-6 h-8 w-32 animate-pulse rounded bg-muted" />
-          }
-        >
-          <MemoListHeader />
-        </Suspense>
-        <Suspense
-          fallback={
-            <div className="space-y-2">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  className="h-10 animate-pulse rounded-md bg-muted"
-                  // biome-ignore lint/suspicious/noArrayIndexKey: skeleton loader uses index
-                  key={i}
-                />
-              ))}
-            </div>
-          }
-        >
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="font-bold text-2xl">メモ一覧</h1>
+          <Suspense fallback={null}>
+            <NewMemoButton />
+          </Suspense>
+        </div>
+        <Suspense fallback={<MemoListSkeleton />}>
           <MemoList />
         </Suspense>
       </main>

--- a/apps/memo/components/header.tsx
+++ b/apps/memo/components/header.tsx
@@ -1,14 +1,19 @@
 import { getCurrentUser } from "@ykzts/supabase/auth";
 import Link from "next/link";
+import { Suspense } from "react";
 import { logout } from "@/app/login/actions";
 
 interface HeaderProps {
   canEdit?: boolean;
 }
 
-export default async function Header({ canEdit = false }: HeaderProps) {
-  const user = await getCurrentUser();
-
+function HeaderChrome({
+  canEdit = false,
+  children,
+}: {
+  canEdit?: boolean;
+  children: React.ReactNode;
+}) {
   return (
     <header className="border-border border-b bg-background">
       <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-4">
@@ -21,25 +26,58 @@ export default async function Header({ canEdit = false }: HeaderProps) {
               編集モード
             </span>
           )}
-          {user ? (
-            <form action={logout}>
-              <button
-                className="text-muted-foreground text-sm hover:text-foreground"
-                type="submit"
-              >
-                ログアウト
-              </button>
-            </form>
-          ) : (
-            <Link
-              className="text-muted-foreground text-sm hover:text-foreground"
-              href="/login"
-            >
-              ログイン
-            </Link>
-          )}
+          {children}
         </nav>
       </div>
     </header>
+  );
+}
+
+async function HeaderAuth() {
+  const user = await getCurrentUser();
+
+  if (user) {
+    return (
+      <form action={logout}>
+        <button
+          className="text-muted-foreground text-sm hover:text-foreground"
+          type="submit"
+        >
+          ログアウト
+        </button>
+      </form>
+    );
+  }
+
+  return (
+    <Link
+      className="text-muted-foreground text-sm hover:text-foreground"
+      href="/login"
+    >
+      ログイン
+    </Link>
+  );
+}
+
+function HeaderAuthFallback() {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block h-5 w-16 animate-pulse rounded bg-muted"
+    />
+  );
+}
+
+/**
+ * Site header with static chrome in the shell and auth controls streamed
+ * behind a small Suspense boundary (private cache / cookies).
+ */
+export default function Header({ canEdit = false }: HeaderProps) {
+  return (
+    <HeaderChrome canEdit={canEdit}>
+      <Suspense fallback={<HeaderAuthFallback />}>
+        <HeaderAuth />
+      </Suspense>
+    </HeaderChrome>
   );
 }

--- a/apps/memo/lib/memos.ts
+++ b/apps/memo/lib/memos.ts
@@ -1,0 +1,136 @@
+import { createBrowserClient } from "@ykzts/supabase/client";
+import { cacheTag } from "next/cache";
+
+interface MemoRow {
+  current_version:
+    | { id: string; title: string | null; content: unknown }
+    | { id: string; title: string | null; content: unknown }[]
+    | null;
+  id: string;
+  path: string;
+  profile_id: string;
+  published_at: string | null;
+  updated_at: string;
+  visibility: string;
+}
+
+interface MemoListRow {
+  id: string;
+  memo_versions: { title: string | null } | { title: string | null }[] | null;
+  path: string;
+  published_at: string | null;
+  updated_at: string;
+  visibility: string;
+}
+
+interface ChildMemoRow {
+  current_version:
+    | { id: string; title: string | null }
+    | { id: string; title: string | null }[]
+    | null;
+  id: string;
+  path: string;
+  visibility: string;
+}
+
+function createPublicClient() {
+  if (
+    !(
+      process.env.NEXT_PUBLIC_SUPABASE_URL &&
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    )
+  ) {
+    return null;
+  }
+
+  // Cookie-free browser client — safe inside "use cache" (no request cookies).
+  return createBrowserClient();
+}
+
+/**
+ * Public memo list for the home page. Cookie-free so it can join the static shell.
+ */
+export async function getPublicMemos(): Promise<MemoListRow[]> {
+  "use cache";
+  cacheTag("memos");
+
+  const supabase = createPublicClient();
+  if (!supabase) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("memos")
+    .select(
+      "id, path, visibility, published_at, updated_at, memo_versions(title)"
+    )
+    .eq("visibility", "public")
+    .order("updated_at", { ascending: false });
+
+  if (error) {
+    console.error("Failed to fetch public memos:", error.message);
+    return [];
+  }
+
+  return (data ?? []) as MemoListRow[];
+}
+
+/**
+ * Single public memo by path. Cookie-free so it can join the static shell.
+ */
+export async function getPublicMemo(memoPath: string): Promise<MemoRow | null> {
+  "use cache";
+  cacheTag("memos");
+
+  const supabase = createPublicClient();
+  if (!supabase) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from("memos")
+    .select(
+      "id, path, visibility, profile_id, published_at, updated_at, current_version:memo_versions!memos_current_version_id_fkey(id, title, content)"
+    )
+    .eq("path", memoPath)
+    .eq("visibility", "public")
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch public memo:", error.message);
+    return null;
+  }
+
+  return data as MemoRow | null;
+}
+
+/**
+ * Child public memos under a path prefix (index pages).
+ */
+export async function getPublicChildMemos(
+  pathPrefix: string
+): Promise<ChildMemoRow[]> {
+  "use cache";
+  cacheTag("memos");
+
+  const supabase = createPublicClient();
+  if (!supabase) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("memos")
+    .select(
+      "id, path, visibility, current_version:memo_versions!memos_current_version_id_fkey(id, title)"
+    )
+    .eq("visibility", "public")
+    .like("path", `${pathPrefix}/%`)
+    .order("path", { ascending: true });
+
+  if (error) {
+    console.error("Failed to fetch child memos:", error.message);
+    return [];
+  }
+
+  return (data ?? []) as ChildMemoRow[];
+}

--- a/apps/portfolio/app/_components/about.tsx
+++ b/apps/portfolio/app/_components/about.tsx
@@ -1,25 +1,7 @@
 import { getProfile } from "@ykzts/supabase/queries";
-import { Skeleton } from "@ykzts/ui/components/skeleton";
-import { Suspense } from "react";
-import range from "@/lib/range";
 import PortableTextBlock from "./portable-text";
 
-function AboutSkeleton() {
-  return (
-    <section className="mx-auto max-w-4xl py-20" id="about">
-      <h2 className="mb-10 font-semibold text-base text-muted-foreground uppercase tracking-widest">
-        About
-      </h2>
-      <div className="space-y-4">
-        {Array.from(range(0, 3), (i) => (
-          <Skeleton className="h-4 w-full" key={`about-${i}`} />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-async function AboutImpl() {
+export default async function About() {
   const profile = await getProfile();
 
   if (!profile.about) {
@@ -35,13 +17,5 @@ async function AboutImpl() {
         <PortableTextBlock value={profile.about} />
       </div>
     </section>
-  );
-}
-
-export default function About() {
-  return (
-    <Suspense fallback={<AboutSkeleton />}>
-      <AboutImpl />
-    </Suspense>
   );
 }

--- a/apps/portfolio/app/_components/hero.tsx
+++ b/apps/portfolio/app/_components/hero.tsx
@@ -1,30 +1,8 @@
 import { getProfile } from "@ykzts/supabase/queries";
 import { Badge } from "@ykzts/ui/components/badge";
-import { Skeleton } from "@ykzts/ui/components/skeleton";
 import Image from "next/image";
-import { Suspense } from "react";
-import range from "@/lib/range";
 
-function HeroSkeleton() {
-  return (
-    <header className="px-6 py-20 md:px-12 lg:px-24 lg:py-28">
-      <div className="mx-auto flex max-w-4xl flex-col-reverse items-start gap-12 lg:flex-row lg:items-center lg:gap-16">
-        <div className="flex-1">
-          <Skeleton className="mb-4 h-12 w-48" />
-          <Skeleton className="mb-8 h-6 w-full" />
-          <div className="flex flex-wrap gap-2">
-            {Array.from(range(0, 10), (i) => (
-              <Skeleton className="h-8 w-24" key={`tech-${i}`} />
-            ))}
-          </div>
-        </div>
-        <Skeleton className="size-80 rounded-2xl" />
-      </div>
-    </header>
-  );
-}
-
-async function HeroImpl() {
+export default async function Hero() {
   const profile = await getProfile();
   const kv = Array.isArray(profile.key_visual)
     ? profile.key_visual[0]
@@ -73,13 +51,5 @@ async function HeroImpl() {
         </div>
       </div>
     </header>
-  );
-}
-
-export default function Hero() {
-  return (
-    <Suspense fallback={<HeroSkeleton />}>
-      <HeroImpl />
-    </Suspense>
   );
 }

--- a/apps/portfolio/app/_components/recent-posts.tsx
+++ b/apps/portfolio/app/_components/recent-posts.tsx
@@ -1,10 +1,7 @@
 import { Link } from "@vercel/microfrontends/next/client";
 import { getPosts } from "@ykzts/supabase/queries";
-import { Skeleton } from "@ykzts/ui/components/skeleton";
 import { getPostUrl } from "@ykzts/utils/blog-urls";
 import { cacheLife } from "next/cache";
-import { Suspense } from "react";
-import range from "@/lib/range";
 
 const RECENT_POSTS_COUNT = 5;
 
@@ -24,30 +21,7 @@ async function getCurrentTime(): Promise<Date> {
   return startOfHour(new Date());
 }
 
-function RecentPostsSkeleton() {
-  return (
-    <section className="mx-auto max-w-4xl py-20" id="blog">
-      <h2 className="mb-12 font-semibold text-base text-muted-foreground uppercase tracking-widest">
-        Blog
-      </h2>
-      <div className="space-y-6">
-        {Array.from(range(0, RECENT_POSTS_COUNT - 1), (i) => (
-          <article
-            className="rounded-xl border border-border bg-card p-6"
-            key={`skeleton-${i}`}
-          >
-            <Skeleton className="mb-3 h-5 w-2/3" />
-            <Skeleton className="mb-2 h-4 w-full" />
-            <Skeleton className="mb-4 h-4 w-4/5" />
-            <Skeleton className="h-3 w-24" />
-          </article>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-async function RecentPostsImpl() {
+export default async function RecentPosts() {
   const now = await getCurrentTime();
 
   let allPosts: Awaited<ReturnType<typeof getPosts>>;
@@ -134,13 +108,5 @@ async function RecentPostsImpl() {
         </Link>
       </div>
     </section>
-  );
-}
-
-export default function RecentPosts() {
-  return (
-    <Suspense fallback={<RecentPostsSkeleton />}>
-      <RecentPostsImpl />
-    </Suspense>
   );
 }

--- a/apps/portfolio/app/_components/social-links.tsx
+++ b/apps/portfolio/app/_components/social-links.tsx
@@ -1,24 +1,8 @@
 import { getProfile } from "@ykzts/supabase/queries";
-import { Skeleton } from "@ykzts/ui/components/skeleton";
-import { Suspense } from "react";
 import Link from "@/components/link";
 import { getSocialInfo } from "@/lib/social-services";
 
-function SocialLinksSkeleton() {
-  const placeholders = ["one", "two", "three", "four", "five"];
-
-  return (
-    <ul className="flex gap-3">
-      {placeholders.map((placeholder) => (
-        <li key={`social-skeleton-${placeholder}`}>
-          <Skeleton className="size-10 rounded-lg" />
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-async function SocialLinksImpl() {
+export default async function SocialLinks() {
   const profile = await getProfile();
 
   return (
@@ -45,13 +29,5 @@ async function SocialLinksImpl() {
         );
       })}
     </ul>
-  );
-}
-
-export default function SocialLinks() {
-  return (
-    <Suspense fallback={<SocialLinksSkeleton />}>
-      <SocialLinksImpl />
-    </Suspense>
   );
 }

--- a/apps/portfolio/app/_components/works.tsx
+++ b/apps/portfolio/app/_components/works.tsx
@@ -1,6 +1,30 @@
 import { getWorks } from "@ykzts/supabase/queries";
+import { Skeleton } from "@ykzts/ui/components/skeleton";
+import { Suspense } from "react";
 import WorksList from "./works-list";
 
+function WorksListFallback() {
+  return (
+    <div className="space-y-8">
+      {["a", "b"].map((key) => (
+        <article
+          className="rounded-xl border border-border bg-card p-8"
+          key={key}
+        >
+          <Skeleton className="mb-4 h-6 w-1/3" />
+          <Skeleton className="mb-2 h-4 w-full" />
+          <Skeleton className="mb-2 h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </article>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Works data is "use cache" and belongs in the static shell.
+ * WorksList reads useSearchParams, so only that client island needs Suspense.
+ */
 export default async function Works() {
   const works = await getWorks();
 
@@ -9,7 +33,9 @@ export default async function Works() {
       <h2 className="mb-12 font-semibold text-base text-muted-foreground uppercase tracking-widest">
         Works
       </h2>
-      <WorksList works={works} />
+      <Suspense fallback={<WorksListFallback />}>
+        <WorksList works={works} />
+      </Suspense>
     </section>
   );
 }

--- a/apps/portfolio/app/_components/works.tsx
+++ b/apps/portfolio/app/_components/works.tsx
@@ -1,33 +1,7 @@
 import { getWorks } from "@ykzts/supabase/queries";
-import { Skeleton } from "@ykzts/ui/components/skeleton";
-import { Suspense } from "react";
-import range from "@/lib/range";
 import WorksList from "./works-list";
 
-function WorksSkeleton() {
-  return (
-    <section className="mx-auto max-w-4xl py-20" id="works">
-      <h2 className="mb-12 font-semibold text-base text-muted-foreground uppercase tracking-widest">
-        Works
-      </h2>
-      <div className="space-y-12">
-        {Array.from(range(0, 2), (i) => (
-          <article
-            className="rounded-xl border border-border bg-card p-6"
-            key={`skeleton-${i}`}
-          >
-            <Skeleton className="mb-4 h-6 w-1/3" />
-            <Skeleton className="mb-2 h-4 w-full" />
-            <Skeleton className="mb-2 h-4 w-full" />
-            <Skeleton className="h-4 w-2/3" />
-          </article>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-async function WorksImpl() {
+export default async function Works() {
   const works = await getWorks();
 
   return (
@@ -37,13 +11,5 @@ async function WorksImpl() {
       </h2>
       <WorksList works={works} />
     </section>
-  );
-}
-
-export default function Works() {
-  return (
-    <Suspense fallback={<WorksSkeleton />}>
-      <WorksImpl />
-    </Suspense>
   );
 }

--- a/apps/portfolio/lib/range.ts
+++ b/apps/portfolio/lib/range.ts
@@ -1,5 +1,0 @@
-export default function* range(start: number, end: number) {
-  for (let i = start; i <= end; i += 1) {
-    yield i;
-  }
-}

--- a/packages/layout/src/components/navigation-wrapper.tsx
+++ b/packages/layout/src/components/navigation-wrapper.tsx
@@ -1,8 +1,7 @@
 import { getProfileOptional, getWorksOptional } from "@ykzts/supabase/queries";
-import { Suspense } from "react";
 import SiteNavigation from "./site-navigation";
 
-async function NavigationImpl() {
+export default async function NavigationWrapper() {
   const [profile, works] = await Promise.all([
     getProfileOptional(),
     getWorksOptional(),
@@ -12,21 +11,4 @@ async function NavigationImpl() {
   const hasWorks = works.length > 0;
 
   return <SiteNavigation hasAbout={hasAbout} hasWorks={hasWorks} />;
-}
-
-function NavigationSkeleton() {
-  return (
-    <div
-      aria-hidden="true"
-      className="h-9 w-32 animate-pulse rounded-md bg-muted"
-    />
-  );
-}
-
-export default function NavigationWrapper() {
-  return (
-    <Suspense fallback={<NavigationSkeleton />}>
-      <NavigationImpl />
-    </Suspense>
-  );
 }

--- a/packages/layout/src/components/site-footer.tsx
+++ b/packages/layout/src/components/site-footer.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@vercel/microfrontends/next/client";
 import { getProfile } from "@ykzts/supabase/queries";
-import { Suspense } from "react";
 import Footer from "./footer";
 import FooterContent from "./footer-content";
 
@@ -15,7 +14,7 @@ const privacyLink = (
   </Link>
 );
 
-async function SiteFooterImpl() {
+export default async function SiteFooter() {
   const profile = await getProfile();
   const kv = profile.key_visual;
 
@@ -45,24 +44,5 @@ async function SiteFooterImpl() {
         privacyLink={privacyLink}
       />
     </Footer>
-  );
-}
-
-function SiteFooterSkeleton() {
-  return (
-    <Footer>
-      <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
-        <div className="h-10 w-48 animate-pulse rounded bg-muted" />
-        <div className="h-5 w-32 animate-pulse rounded bg-muted" />
-      </div>
-    </Footer>
-  );
-}
-
-export default function SiteFooter() {
-  return (
-    <Suspense fallback={<SiteFooterSkeleton />}>
-      <SiteFooterImpl />
-    </Suspense>
   );
 }

--- a/packages/supabase/src/queries.ts
+++ b/packages/supabase/src/queries.ts
@@ -378,6 +378,10 @@ export async function getPosts(page = 1, now = new Date()): Promise<Post[]> {
     throw new Error(`Failed to fetch posts: ${error.message}`);
   }
 
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
   return data.map((post) => ({
     content: extractVersionContent(post.current_version),
     excerpt: post.excerpt,


### PR DESCRIPTION
## Summary
- Remove coarse `Suspense` wrappers around already-cached (`"use cache"`) public content in portfolio, layout, and blog so that content joins the static shell instead of streaming as a skeleton.
- Refactor memo so public data uses cookie-free `"use cache"` queries, header chrome stays static, and blank whole-page `fallback={null}` boundaries are replaced with shaped, narrower ones.
- Rely on admin `proxy` for auth instead of a layout-wide AuthGuard Suspense; keep only granular boundaries for private cache, `params`, and `useSearchParams`.

## Test plan
- [ ] `pnpm --filter @ykzts/portfolio typecheck` / `blog` / `memo` / `admin`
- [ ] `pnpm --filter @ykzts/admin build` and `pnpm --filter @ykzts/memo build` (expect `◐` Partial Prerender routes)
- [ ] Portfolio home: hero/about/works/posts appear in first paint (no section-wide skeletons when cache is warm)
- [ ] Blog index and post detail: list/body in shell; draft route still streams behind skeleton
- [ ] Memo list/detail: public content loads; owner/draft paths and `/new` still require auth correctly
- [ ] Admin: unauthenticated users redirected by proxy; shell (header/nav) visible; dashboard/posts/works forms still work