### PR TITLE
chore: enable Turbopack build FS cache and Rust React Compiler

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -9,7 +9,8 @@ const HTTPS_PROTOCOL_RE = /^https:/;
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    turbopackFileSystemCacheForDev: true,
+    turbopackFileSystemCacheForBuild: true,
+    turbopackRustReactCompiler: true,
   },
   headers() {
     const supabaseHost = getSupabaseHost();

--- a/apps/blog-legacy/next.config.ts
+++ b/apps/blog-legacy/next.config.ts
@@ -5,7 +5,8 @@ import { createLegacyRedirects } from "./redirects";
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    turbopackFileSystemCacheForDev: true,
+    turbopackFileSystemCacheForBuild: true,
+    turbopackRustReactCompiler: true,
   },
   partialPrefetching: true,
   reactCompiler: true,

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -7,7 +7,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    turbopackFileSystemCacheForDev: true,
+    turbopackFileSystemCacheForBuild: true,
+    turbopackRustReactCompiler: true,
   },
   headers() {
     return Promise.resolve([

--- a/apps/memo/next.config.ts
+++ b/apps/memo/next.config.ts
@@ -9,7 +9,8 @@ const HTTPS_PROTOCOL_RE = /^https:/;
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    turbopackFileSystemCacheForDev: true,
+    turbopackFileSystemCacheForBuild: true,
+    turbopackRustReactCompiler: true,
   },
   headers() {
     const supabaseHost = getSupabaseHost();

--- a/apps/portfolio/next.config.ts
+++ b/apps/portfolio/next.config.ts
@@ -14,7 +14,8 @@ const nextConfig: NextConfig = {
     mdxRs: {
       mdxType: "gfm",
     },
-    turbopackFileSystemCacheForDev: true,
+    turbopackFileSystemCacheForBuild: true,
+    turbopackRustReactCompiler: true,
   },
   headers() {
     return Promise.resolve([


### PR DESCRIPTION
## Summary

- Remove explicit `experimental.turbopackFileSystemCacheForDev: true` from all Next.js apps (`admin`, `blog`, `blog-legacy`, `memo`, `portfolio`).
  - This option is **already `true` by default** in Next.js 16.3, so the explicit setting was redundant and did not change behavior.
  - Dev filesystem cache remains enabled via the default.
- Enable `experimental.turbopackFileSystemCacheForBuild: true` for production/build Turbopack filesystem caching.
- Enable `experimental.turbopackRustReactCompiler: true` so Turbopack can use the Rust React Compiler path (requires existing `reactCompiler: true`).

## Test plan

- [ ] Confirm each app still starts with `pnpm dev` (or filtered `pnpm --filter <app> dev`)
- [ ] Run `pnpm build` and verify production builds succeed for all apps
- [ ] Spot-check that React Compiler behavior is unchanged in UI (no runtime regressions)
- [ ] Review CI (typecheck/lint/build) on this PR