### PR TITLE
chore: enable useTypeScriptCli with TypeScript 7

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -11,6 +11,7 @@ const nextConfig: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
+    useTypeScriptCli: true,
   },
   headers() {
     const supabaseHost = getSupabaseHost();

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -29,7 +29,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@vercel/config": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "postcss": "catalog:",

--- a/apps/blog-legacy/next.config.ts
+++ b/apps/blog-legacy/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
+    useTypeScriptCli: true,
   },
   partialPrefetching: true,
   reactCompiler: true,

--- a/apps/blog-legacy/package.json
+++ b/apps/blog-legacy/package.json
@@ -16,7 +16,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
+    useTypeScriptCli: true,
   },
   headers() {
     return Promise.resolve([

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -34,7 +34,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@vercel/config": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@ykzts/tsconfig": "workspace:*",

--- a/apps/memo/next.config.ts
+++ b/apps/memo/next.config.ts
@@ -11,6 +11,7 @@ const nextConfig: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
+    useTypeScriptCli: true,
   },
   headers() {
     const supabaseHost = getSupabaseHost();

--- a/apps/memo/package.json
+++ b/apps/memo/package.json
@@ -23,7 +23,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "postcss": "catalog:",
     "tailwindcss": "catalog:",

--- a/apps/portfolio/next.config.ts
+++ b/apps/portfolio/next.config.ts
@@ -16,6 +16,7 @@ const nextConfig: NextConfig = {
     },
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
+    useTypeScriptCli: true,
   },
   headers() {
     return Promise.resolve([

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -40,7 +40,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "axe-core": "4.12.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -38,7 +38,6 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "jsdom": "catalog:",

--- a/packages/site-config/package.json
+++ b/packages/site-config/package.json
@@ -14,7 +14,6 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -11,7 +11,6 @@
   "description": "Supabase database type definitions for ykzts applications",
   "devDependencies": {
     "@types/node": "catalog:",
-    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@portabletext/types": "catalog:",
     "@types/node": "catalog:",
-    "@typescript/native": "catalog:",
     "@ykzts/tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ catalogs:
     '@types/react-dom':
       specifier: 19.2.3
       version: 19.2.3
-    '@typescript/native':
-      specifier: npm:typescript@7.0.2
-      version: 7.0.2
     '@vercel/analytics':
       specifier: 2.0.1
       version: 2.0.1
@@ -106,8 +103,8 @@ catalogs:
       specifier: 1.4.0
       version: 1.4.0
     typescript:
-      specifier: npm:@typescript/typescript6@6.0.2
-      version: 6.0.2
+      specifier: 7.0.2
+      version: 7.0.2
     vitest:
       specifier: 4.1.10
       version: 4.1.10
@@ -219,9 +216,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@vercel/config':
         specifier: 'catalog:'
         version: 0.5.5
@@ -233,7 +227,7 @@ importers:
         version: 8.5.17
       shadcn:
         specifier: 'catalog:'
-        version: 4.13.0(@typescript/typescript6@6.0.2)
+        version: 4.13.0(typescript@7.0.2)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.2
@@ -242,7 +236,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -340,9 +334,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@vercel/config':
         specifier: 'catalog:'
         version: 0.5.5
@@ -360,7 +351,7 @@ importers:
         version: 8.5.17
       shadcn:
         specifier: 'catalog:'
-        version: 4.13.0(@typescript/typescript6@6.0.2)
+        version: 4.13.0(typescript@7.0.2)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.2
@@ -369,7 +360,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -401,15 +392,12 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -474,9 +462,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -491,7 +476,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
 
   apps/portfolio:
     dependencies:
@@ -604,9 +589,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -627,7 +609,7 @@ importers:
         version: 8.5.17
       shadcn:
         specifier: 'catalog:'
-        version: 4.13.0(@typescript/typescript6@6.0.2)
+        version: 4.13.0(typescript@7.0.2)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.2
@@ -636,7 +618,7 @@ importers:
         version: 1.4.0
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vite:
         specifier: 8.1.4
         version: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
@@ -648,34 +630,34 @@ importers:
     dependencies:
       '@lexical/code':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@lexical/link':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@lexical/list':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@lexical/react':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.31)
+        version: 0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)(yjs@13.6.31)
       '@lexical/rich-text':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@lexical/selection':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@lexical/table':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@lexical/utils':
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       '@ykzts/ui':
         specifier: workspace:*
         version: link:../ui
       lexical:
         specifier: 0.47.0
-        version: 0.47.0(@typescript/typescript6@6.0.2)
+        version: 0.47.0(typescript@7.0.2)
       lucide-react:
         specifier: 'catalog:'
         version: 1.24.0(react@19.2.7)
@@ -695,9 +677,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@26.0.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -706,7 +685,7 @@ importers:
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.0.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -756,9 +735,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -773,7 +749,7 @@ importers:
         version: 16.3.0-preview.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -783,15 +759,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -820,15 +793,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
 
   packages/tsconfig: {}
 
@@ -868,15 +838,12 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
 
   packages/utils:
     dependencies:
@@ -905,15 +872,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
-      '@typescript/native':
-        specifier: 'catalog:'
-        version: typescript@7.0.2
       '@ykzts/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        version: 7.0.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -3153,10 +3117,6 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
-
-  '@typescript/typescript6@6.0.2':
-    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
-    hasBin: true
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -7014,11 +6974,6 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -8582,253 +8537,253 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lexical/a11y@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/a11y@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/clipboard@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/clipboard@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/list': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/list': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
       '@types/trusted-types': 2.0.7
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/code-core@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/code-core@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/code-prism@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/code-prism@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/code-core': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/code-core': 0.47.0(typescript@7.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
       prismjs: 1.30.0
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/code@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/code@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/code-core': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/code-prism': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/code-core': 0.47.0(typescript@7.0.2)
+      '@lexical/code-prism': 0.47.0(typescript@7.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/devtools-core@0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@lexical/devtools-core@0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)':
     dependencies:
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/link': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/mark': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/table': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/link': 0.47.0(typescript@7.0.2)
+      '@lexical/mark': 0.47.0(typescript@7.0.2)
+      '@lexical/table': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/dragon@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/dragon@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/extension@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/extension@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
       '@preact/signals-core': 1.14.3
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/hashtag@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/hashtag@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/text': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/text': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/history@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/history@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/html@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/html@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/internal@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/internal@0.47.0(typescript@7.0.2)':
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/link@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/link@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/list@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/list@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/mark@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/mark@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/markdown@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/markdown@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/code-core': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/link': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/list': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/rich-text': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/text': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/code-core': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/link': 0.47.0(typescript@7.0.2)
+      '@lexical/list': 0.47.0(typescript@7.0.2)
+      '@lexical/rich-text': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      '@lexical/text': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/overflow@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/overflow@0.47.0(typescript@7.0.2)':
     dependencies:
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/plain-text@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/plain-text@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/dragon': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/clipboard': 0.47.0(typescript@7.0.2)
+      '@lexical/dragon': 0.47.0(typescript@7.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/react@0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.31)':
+  '@lexical/react@0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)(yjs@13.6.31)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@lexical/a11y': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/devtools-core': 0.47.0(@typescript/typescript6@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@lexical/dragon': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/hashtag': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/history': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/link': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/list': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/mark': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/markdown': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/overflow': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/plain-text': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/rich-text': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/table': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/text': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/yjs': 0.47.0(@typescript/typescript6@6.0.2)(yjs@13.6.31)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/a11y': 0.47.0(typescript@7.0.2)
+      '@lexical/devtools-core': 0.47.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+      '@lexical/dragon': 0.47.0(typescript@7.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/hashtag': 0.47.0(typescript@7.0.2)
+      '@lexical/history': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/link': 0.47.0(typescript@7.0.2)
+      '@lexical/list': 0.47.0(typescript@7.0.2)
+      '@lexical/mark': 0.47.0(typescript@7.0.2)
+      '@lexical/markdown': 0.47.0(typescript@7.0.2)
+      '@lexical/overflow': 0.47.0(typescript@7.0.2)
+      '@lexical/plain-text': 0.47.0(typescript@7.0.2)
+      '@lexical/rich-text': 0.47.0(typescript@7.0.2)
+      '@lexical/table': 0.47.0(typescript@7.0.2)
+      '@lexical/text': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      '@lexical/yjs': 0.47.0(typescript@7.0.2)(yjs@13.6.31)
+      lexical: 0.47.0(typescript@7.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
       yjs: 13.6.31
 
-  '@lexical/rich-text@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/rich-text@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/dragon': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/clipboard': 0.47.0(typescript@7.0.2)
+      '@lexical/dragon': 0.47.0(typescript@7.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/selection@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/selection@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/table@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/table@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/clipboard': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/extension': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/html': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/utils': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/clipboard': 0.47.0(typescript@7.0.2)
+      '@lexical/extension': 0.47.0(typescript@7.0.2)
+      '@lexical/html': 0.47.0(typescript@7.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/utils': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/text@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/text@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/utils@0.47.0(@typescript/typescript6@6.0.2)':
+  '@lexical/utils@0.47.0(typescript@7.0.2)':
     dependencies:
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
-  '@lexical/yjs@0.47.0(@typescript/typescript6@6.0.2)(yjs@13.6.31)':
+  '@lexical/yjs@0.47.0(typescript@7.0.2)(yjs@13.6.31)':
     dependencies:
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
-      '@lexical/selection': 0.47.0(@typescript/typescript6@6.0.2)
-      lexical: 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
+      '@lexical/selection': 0.47.0(typescript@7.0.2)
+      lexical: 0.47.0(typescript@7.0.2)
       yjs: 13.6.31
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
   '@lhci/cli@0.15.1':
     dependencies:
@@ -9963,10 +9918,6 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript6@6.0.2':
-    dependencies:
-      '@typescript/old': typescript@6.0.3
-
   '@ungap/structured-clone@1.3.1': {}
 
   '@vercel/analytics@2.0.1(next@16.3.0-preview.6(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
@@ -10700,15 +10651,6 @@ snapshots:
       cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.6.1
       typescript: 7.0.2
-
-  cosmiconfig@9.0.2(@typescript/typescript6@6.0.2):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.1
-      js-yaml: 4.2.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
 
   cosmiconfig@9.0.2(typescript@7.0.2):
     dependencies:
@@ -12167,11 +12109,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lexical@0.47.0(@typescript/typescript6@6.0.2):
+  lexical@0.47.0(typescript@7.0.2):
     dependencies:
-      '@lexical/internal': 0.47.0(@typescript/typescript6@6.0.2)
+      '@lexical/internal': 0.47.0(typescript@7.0.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
   lib0@0.2.117:
     dependencies:
@@ -13936,7 +13878,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.13.0(@typescript/typescript6@6.0.2):
+  shadcn@4.13.0(typescript@7.0.2):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
@@ -13947,7 +13889,7 @@ snapshots:
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.2
       commander: 14.0.3
-      cosmiconfig: 9.0.2(@typescript/typescript6@6.0.2)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
       dedent: 1.7.2
       deepmerge: 4.3.1
       diff: 8.0.4
@@ -14444,8 +14386,6 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
-
-  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,10 +18,6 @@ catalog:
   '@types/node': 24.13.3
   '@types/react': 19.2.17
   '@types/react-dom': 19.2.3
-  # TypeScript 7 (native) CLI as tsc; installed as @typescript/native to avoid
-  # conflicting with the TypeScript 6 API package below.
-  # See https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0
-  '@typescript/native': npm:typescript@7.0.2
   '@vercel/analytics': 2.0.1
   '@vercel/config': 0.5.5
   '@vercel/microfrontends': 2.4.0
@@ -41,9 +37,7 @@ catalog:
   tailwind-merge: 3.6.0
   tailwindcss: 4.3.2
   tw-animate-css: 1.4.0
-  # TypeScript 6 API + tsc6 binary (for tools that still need the classic API,
-  # e.g. typescript-eslint). Alias keeps the import name `typescript`.
-  typescript: npm:@typescript/typescript6@6.0.2
+  typescript: 7.0.2
   vitest: 4.1.10
   zod: 4.4.3
 


### PR DESCRIPTION
## Summary

- Enable `experimental.useTypeScriptCli` in all Next.js apps so `next build` typechecks via the project-local `tsc` CLI ([vercel/next.js#95639](https://github.com/vercel/next.js/pull/95639)).
- Install `typescript@7.0.2` as the single compiler package and remove the TypeScript 6 / `@typescript/native` side-by-side setup, which is no longer needed once Next uses the CLI instead of the JS Compiler API.

## Test plan

- [x] `pnpm --filter @ykzts/blog-legacy build` (shows `✓ useTypeScriptCli`)
- [x] `pnpm --filter @ykzts/portfolio build`
- [x] `pnpm typecheck --force`
- [x] `pnpm check`
- [x] commitlint loads `commitlint.config.ts`
- [x] `pnpm --filter @ykzts/editor test`