### PR TITLE
chore: limit renovate package updates to weekly

### DIFF
--- a/renovate-config/default.json5
+++ b/renovate-config/default.json5
@@ -37,7 +37,7 @@
       groupName: 'immich docker containers',
       groupSlug: 'immich',
       matchDatasources: ['docker'],
-      matchPackageNames: ['ghcr.io/immich-app/**'],
+      matchPackageNames: ['ghcr.io/immich-app/**']
     },
     {
       groupName: 'mastodon docker containers',
@@ -49,6 +49,11 @@
       groupName: 'google terraform providers',
       matchDatasources: ['terraform-provider'],
       matchDepNames: ['google', 'google-beta']
+    },
+    {
+      description: 'Limit renovate package updates to once a week',
+      extends: ['schedule:weekly'],
+      matchPackageNames: ['renovate']
     },
     {
       groupName: 'skaffold',


### PR DESCRIPTION
## Summary
- Add a `packageRules` entry so the `renovate` package only gets update PRs on the weekly schedule (`schedule:weekly`).
- Reduces noise from frequent Renovate self-updates while still keeping the validation tool reasonably current.

## Test plan
- [x] `pnpm --filter @ykzts/renovate-config validate` passes
- [ ] After merge, confirm Renovate does not open `renovate` update PRs outside the weekly window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Renovate による更新チェックの頻度を週1回に制限し、更新通知や自動更新の発生頻度を抑えました。
  - 設定ファイルの書式を整理し、設定の一貫性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->