### PR TITLE
chore: install Claude Code and Grok Build in devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:4.0.0": {
       "version": "4.0.0",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
     }
   },
   "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5": {},
     "ghcr.io/devcontainers/features/docker-in-docker:4.0.0": {},
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {}
   },
@@ -19,6 +20,8 @@
   "runArgs": ["--memory=12g", "--memory-swap=24g", "--cpus=4.0"],
   "image": "mcr.microsoft.com/devcontainers/typescript-node:5-24-bookworm",
   "mounts": [
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=grok-config-${devcontainerId},target=/home/node/.grok,type=volume",
     "source=ykzts-com-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
   ],
   "name": "ykzts.com",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,6 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -euxo pipefail
 
-[ -d node_modules/ ] && sudo chown -R node node_modules/
+sudo apt-get update
+sudo apt-get install -y fonts-noto-cjk
+
+# Named volumes are often created as root; ensure the container user owns them.
+[ -d /home/node/.claude/ ] && sudo chown -R node:node /home/node/.claude/
+[ -d /home/node/.grok/ ] && sudo chown -R node:node /home/node/.grok/
+[ -d node_modules/ ] && sudo chown -R node:node node_modules/
+
+# Install Grok Build CLI (https://x.ai/cli)
+curl -fsSL https://x.ai/cli/install.sh | bash
+
 pnpm install


### PR DESCRIPTION
## Summary
- Add Anthropic's Claude Code Dev Container Feature (`claude-code:1.0.5`) and lock it in `devcontainer-lock.json`.
- Persist Claude Code and Grok Build config across rebuilds with named volumes for `~/.claude` and `~/.grok`.
- Install Grok Build CLI in `post-create.sh` (before project `pnpm install`), and ensure volume ownership for the container user.

## Test plan
- [ ] Rebuild the devcontainer and confirm Claude Code is available (`claude --version` or the VS Code extension).
- [ ] Confirm Grok Build is installed after post-create (`grok --version` or `which grok`).
- [ ] Rebuild again and verify auth/config under `~/.claude` and `~/.grok` is preserved via the named volumes.
- [ ] Confirm `pnpm install` still completes successfully during post-create.