### PR TITLE
fix(editor): align rich text editor with typography prose display

### DIFF
--- a/apps/blog/components/portable-text.tsx
+++ b/apps/blog/components/portable-text.tsx
@@ -4,6 +4,7 @@ import {
   type PortableTextMarkComponentProps,
   type PortableTextReactComponents,
 } from "@portabletext/react";
+import { proseContent } from "@ykzts/ui/lib/prose";
 import type {
   CodeBlock,
   ImageBlock,
@@ -207,7 +208,7 @@ export default function PortableTextBlock({
   ...props
 }: PortableTextProps) {
   return (
-    <div className="prose prose-theme max-w-none prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+    <div className={proseContent("max-w-none")}>
       <PortableText
         {...props}
         components={portableTextComponents}

--- a/apps/memo/components/portable-text.tsx
+++ b/apps/memo/components/portable-text.tsx
@@ -4,6 +4,7 @@ import {
   type PortableTextReactComponents,
 } from "@portabletext/react";
 import type { PortableTextBlock } from "@portabletext/types";
+import { proseContent } from "@ykzts/ui/lib/prose";
 import type { ComponentProps } from "react";
 import Link from "@/components/link";
 
@@ -36,7 +37,7 @@ export default function MemoPortableText({
   ...props
 }: PortableTextProps) {
   return (
-    <div className="prose max-w-none">
+    <div className={proseContent("max-w-none")}>
       <PortableText
         {...props}
         components={portableTextComponents}

--- a/apps/portfolio/app/(docs)/layout.tsx
+++ b/apps/portfolio/app/(docs)/layout.tsx
@@ -1,10 +1,11 @@
 import { Link } from "@vercel/microfrontends/next/client";
+import { proseContent } from "@ykzts/ui/lib/prose";
 import { ArrowLeft } from "lucide-react";
 
 export default function DocsLayout({ children }: LayoutProps<"/">) {
   return (
     <div className="min-h-dvh px-6 py-16 md:px-12 lg:px-24">
-      <main className="prose prose-theme mx-auto max-w-3xl prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+      <main className={proseContent("mx-auto max-w-3xl")}>
         {children}
 
         <p className="mt-16">

--- a/apps/portfolio/app/@modal/(.)privacy/page.tsx
+++ b/apps/portfolio/app/@modal/(.)privacy/page.tsx
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@ykzts/ui/components/dialog";
+import { proseContent } from "@ykzts/ui/lib/prose";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import PrivacyContent from "@/docs/privacy.mdx";
@@ -28,7 +29,7 @@ export default function PrivacyModal() {
           <DialogTitle>プライバシーポリシー</DialogTitle>
         </DialogHeader>
         <div className="-mx-4 min-h-0 flex-1 overflow-y-auto px-8">
-          <div className="prose prose-theme prose-base max-w-none prose-p:text-base prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+          <div className={proseContent("max-w-none")}>
             <PrivacyContent />
           </div>
         </div>

--- a/apps/portfolio/app/_components/about.tsx
+++ b/apps/portfolio/app/_components/about.tsx
@@ -1,4 +1,5 @@
 import { getProfile } from "@ykzts/supabase/queries";
+import { proseContent } from "@ykzts/ui/lib/prose";
 import PortableTextBlock from "./portable-text";
 
 export default async function About() {
@@ -13,7 +14,7 @@ export default async function About() {
       <h2 className="mb-10 font-semibold text-base text-muted-foreground uppercase tracking-widest">
         About
       </h2>
-      <div className="prose prose-theme max-w-none prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+      <div className={proseContent("max-w-none")}>
         <PortableTextBlock value={profile.about} />
       </div>
     </section>

--- a/apps/portfolio/app/_components/works-list.tsx
+++ b/apps/portfolio/app/_components/works-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { proseContent } from "@ykzts/ui/lib/prose";
 import type { PortableTextValue } from "@ykzts/utils/portable-text";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
@@ -123,7 +124,7 @@ export default function WorksList({
                 {work.title}
               </h3>
               {!!work.content && (
-                <div className="prose prose-theme prose-base max-w-none prose-p:text-base prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline">
+                <div className={proseContent("max-w-none")}>
                   <PortableTextBlock value={work.content} />
                 </div>
               )}

--- a/packages/editor/src/__tests__/prose-table-node.test.ts
+++ b/packages/editor/src/__tests__/prose-table-node.test.ts
@@ -1,0 +1,99 @@
+import {
+  $createTableNodeWithDimensions,
+  $isTableNode,
+  TableCellNode,
+  TableNode,
+  TableRowNode,
+} from "@lexical/table";
+import { $getRoot, createEditor } from "lexical";
+import { describe, expect, it } from "vitest";
+import {
+  $createProseTableNode,
+  $isProseTableNode,
+  ProseTableNode,
+} from "../nodes/prose-table-node";
+
+const THEAD_CONTAINS_TR = /<thead[^>]*>[\s\S]*<tr/;
+const TBODY_CONTAINS_TR = /<tbody[^>]*>[\s\S]*<tr/;
+
+function createTestEditor() {
+  return createEditor({
+    namespace: "ProseTableTest",
+    nodes: [
+      ProseTableNode,
+      {
+        replace: TableNode,
+        with: () => $createProseTableNode(),
+        withKlass: ProseTableNode,
+      },
+      TableCellNode,
+      TableRowNode,
+    ],
+    onError: (error) => {
+      throw error;
+    },
+  });
+}
+
+describe("ProseTableNode", () => {
+  it("creates editor without hanging", () => {
+    const editor = createTestEditor();
+    expect(editor).toBeDefined();
+  });
+
+  it("replaces TableNode factories with ProseTableNode", () => {
+    const editor = createTestEditor();
+    editor.update(
+      () => {
+        const table = $createTableNodeWithDimensions(2, 2, {
+          columns: false,
+          rows: true,
+        });
+        expect($isTableNode(table)).toBe(true);
+        expect($isProseTableNode(table)).toBe(true);
+        $getRoot().clear();
+        $getRoot().append(table);
+      },
+      { discrete: true }
+    );
+  });
+
+  it("puts header row in thead and body rows in tbody", () => {
+    const editor = createTestEditor();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    editor.setRootElement(container);
+
+    editor.update(
+      () => {
+        // First row = th (header), remaining rows = td — same as insert UI
+        const table = $createTableNodeWithDimensions(3, 2, {
+          columns: false,
+          rows: true,
+        });
+        $getRoot().clear();
+        $getRoot().append(table);
+      },
+      { discrete: true }
+    );
+
+    const html = container.innerHTML;
+    expect(html).toContain("<table");
+    expect(html).toMatch(THEAD_CONTAINS_TR);
+    expect(html).toMatch(TBODY_CONTAINS_TR);
+
+    const table = container.querySelector("table");
+    expect(table?.tHead?.rows).toHaveLength(1);
+    expect(table?.tBodies[0]?.rows).toHaveLength(2);
+    expect(
+      [...(table?.tHead?.rows[0]?.cells ?? [])].every((c) => c.tagName === "TH")
+    ).toBe(true);
+    expect(
+      [...(table?.tBodies[0]?.rows[0]?.cells ?? [])].every(
+        (c) => c.tagName === "TD"
+      )
+    ).toBe(true);
+
+    container.remove();
+  });
+});

--- a/packages/editor/src/nodes/prose-table-node.ts
+++ b/packages/editor/src/nodes/prose-table-node.ts
@@ -1,0 +1,256 @@
+import {
+  $isScrollableTablesActive,
+  type SerializedTableNode,
+  TableNode,
+} from "@lexical/table";
+import type {
+  DOMExportOutput,
+  EditorConfig,
+  ElementDOMSlot,
+  LexicalEditor,
+  LexicalNode,
+} from "lexical";
+import {
+  $getDocument,
+  addClassNamesToElement,
+  isHTMLElement,
+  isHTMLTableRowElement,
+  setDOMStyleFromCSS,
+  setDOMUnmanaged,
+} from "lexical";
+
+const PATCHED = Symbol.for("ykzts.proseTable.removeChildPatched");
+
+function isHTMLTableElement(node: unknown): node is HTMLTableElement {
+  return isHTMLElement(node) && node.nodeName === "TABLE";
+}
+
+function getTableElementFromDOM(dom: HTMLElement): HTMLTableElement {
+  if (isHTMLTableElement(dom)) {
+    return dom;
+  }
+  const table = dom.querySelector("table");
+  if (!isHTMLTableElement(table)) {
+    throw new Error("ProseTableNode: expected a <table> in createDOM output");
+  }
+  return table;
+}
+
+function isHeaderRow(row: HTMLTableRowElement): boolean {
+  const cells = [...row.cells];
+  return cells.length > 0 && cells.every((cell) => cell.tagName === "TH");
+}
+
+/**
+ * Ensure thead + tbody exist (published Portable Text shape).
+ * Rows are placed by the DOM slot, not left as direct table children.
+ */
+function ensureTableSections(table: HTMLTableElement): {
+  thead: HTMLTableSectionElement;
+  tbody: HTMLTableSectionElement;
+} {
+  const thead = table.tHead ?? table.createTHead();
+  const tbody = table.tBodies[0] ?? table.createTBody();
+  return { tbody, thead };
+}
+
+/**
+ * Lexical's $destroyNode only detaches when `dom.parentNode === slot.element`.
+ * Rows live under thead/tbody, so teach <table> to remove descendants too.
+ */
+function patchTableRemoveChild(table: HTMLTableElement): void {
+  const patched = table as HTMLTableElement & {
+    [PATCHED]?: boolean;
+  };
+  if (patched[PATCHED]) {
+    return;
+  }
+  patched[PATCHED] = true;
+  const nativeRemoveChild = table.removeChild.bind(table);
+  table.removeChild = ((child: Node) => {
+    if (child.parentNode && child.parentNode !== table) {
+      return child.parentNode.removeChild(child);
+    }
+    return nativeRemoveChild(child);
+  }) as typeof table.removeChild;
+}
+
+function insertRowIntoSection(
+  table: HTMLTableElement,
+  row: HTMLTableRowElement,
+  before: Node | null
+): void {
+  const { thead, tbody } = ensureTableSections(table);
+  const section = isHeaderRow(row) ? thead : tbody;
+
+  if (before && before.parentNode === section) {
+    section.insertBefore(row, before);
+    return;
+  }
+
+  if (before && isHTMLTableRowElement(before)) {
+    if (section === tbody && thead.contains(before)) {
+      // Body row inserted "before" a header-relative anchor → start of tbody
+      tbody.insertBefore(row, tbody.firstChild);
+      return;
+    }
+    if (section === thead && tbody.contains(before)) {
+      thead.appendChild(row);
+      return;
+    }
+  }
+
+  section.appendChild(row);
+}
+
+/**
+ * TableNode that matches published Portable Text HTML:
+ * `table > thead? > tr` (all-th rows) + `table > tbody > tr` (body rows).
+ *
+ * Core Lexical mounts every row as `table > tr`, so typography's
+ * `thead` / `tbody` selectors never fire. This node routes rows into sections
+ * while editing (same structure as apps/blog portable-text tables).
+ */
+export class ProseTableNode extends TableNode {
+  static override getType(): string {
+    return "prose-table";
+  }
+
+  static override clone(node: ProseTableNode): ProseTableNode {
+    return new ProseTableNode(node.__key);
+  }
+
+  static override importJSON(
+    serializedNode: SerializedTableNode
+  ): ProseTableNode {
+    return new ProseTableNode().updateFromJSON(serializedNode);
+  }
+
+  override createDOM(
+    config: EditorConfig,
+    editor?: LexicalEditor
+  ): HTMLElement {
+    const tableElement = $getDocument().createElement("table");
+    if (this.__style) {
+      setDOMStyleFromCSS(tableElement.style, this.__style);
+    }
+
+    const colGroup = $getDocument().createElement("colgroup");
+    tableElement.appendChild(colGroup);
+    setDOMUnmanaged(colGroup);
+
+    // Sections ready for row routing in getDOMSlot
+    tableElement.appendChild($getDocument().createElement("thead"));
+    tableElement.appendChild($getDocument().createElement("tbody"));
+
+    addClassNamesToElement(tableElement, config.theme.table);
+    this.updateTableElement(null, tableElement, config);
+    patchTableRemoveChild(tableElement);
+
+    if (editor && $isScrollableTablesActive(editor)) {
+      const wrapperElement = $getDocument().createElement("div");
+      const classes = config.theme.tableScrollableWrapper;
+      if (classes) {
+        addClassNamesToElement(wrapperElement, classes);
+      } else {
+        wrapperElement.style.overflowX = "auto";
+      }
+      wrapperElement.appendChild(tableElement);
+      this.updateTableWrapper(null, wrapperElement, tableElement, config);
+      return wrapperElement;
+    }
+
+    return tableElement;
+  }
+
+  override getDOMSlot(element: HTMLElement): ElementDOMSlot<HTMLTableElement> {
+    const tableElement = getTableElementFromDOM(element);
+    ensureTableSections(tableElement);
+    patchTableRemoveChild(tableElement);
+
+    const colgroup = tableElement.querySelector("colgroup");
+    const slot = super
+      .getDOMSlot(element)
+      .withElement(tableElement)
+      .withAfter(colgroup);
+
+    // Route rows into thead (all-th) / tbody so structure matches published HTML.
+    // ElementDOMSlot is not constructable from outside Lexical; patch the instance.
+    const originalInsertChild = slot.insertChild.bind(slot);
+    const originalReplaceChild = slot.replaceChild.bind(slot);
+
+    slot.insertChild = (dom: Node) => {
+      if (isHTMLTableRowElement(dom)) {
+        insertRowIntoSection(tableElement, dom, slot.getInsertionAnchor());
+        return slot;
+      }
+      return originalInsertChild(dom);
+    };
+
+    slot.removeChild = (dom: Node) => {
+      if (dom.parentNode) {
+        dom.parentNode.removeChild(dom);
+        return slot;
+      }
+      return slot;
+    };
+
+    slot.replaceChild = (dom: Node, prevDom: Node) => {
+      if (prevDom.parentNode) {
+        prevDom.parentNode.replaceChild(dom, prevDom);
+        if (isHTMLTableRowElement(dom)) {
+          insertRowIntoSection(
+            tableElement,
+            dom,
+            isHTMLTableRowElement(dom.nextSibling) ? dom.nextSibling : null
+          );
+        }
+        return slot;
+      }
+      return originalReplaceChild(dom, prevDom);
+    };
+
+    slot.getFirstChild = () =>
+      tableElement.tHead?.rows[0] ?? tableElement.tBodies[0]?.rows[0] ?? null;
+
+    return slot;
+  }
+
+  override exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const output = super.exportDOM(editor);
+    const { after, element } = output;
+
+    return {
+      after: (dom) => {
+        const exported = after ? after(dom) : dom;
+        let tableElement: HTMLElement | null = null;
+        if (isHTMLTableElement(exported)) {
+          tableElement = exported;
+        } else if (isHTMLElement(exported)) {
+          tableElement = exported.querySelector("table");
+        }
+        if (!isHTMLTableElement(tableElement)) {
+          return null;
+        }
+
+        // Drop empty thead if no header rows (keeps markup tidy)
+        const thead = tableElement.tHead;
+        if (thead && thead.rows.length === 0) {
+          thead.remove();
+        }
+        return tableElement;
+      },
+      element,
+    };
+  }
+}
+
+export function $createProseTableNode(): ProseTableNode {
+  return new ProseTableNode();
+}
+
+export function $isProseTableNode(
+  node: LexicalNode | null | undefined
+): node is ProseTableNode {
+  return node instanceof ProseTableNode;
+}

--- a/packages/editor/src/nodes/prose-table-node.ts
+++ b/packages/editor/src/nodes/prose-table-node.ts
@@ -233,10 +233,15 @@ export class ProseTableNode extends TableNode {
           return null;
         }
 
-        // Drop empty thead if no header rows (keeps markup tidy)
+        // Drop empty sections (header-only or body-only tables)
         const thead = tableElement.tHead;
         if (thead && thead.rows.length === 0) {
           thead.remove();
+        }
+        for (const tbody of [...tableElement.tBodies]) {
+          if (tbody.rows.length === 0) {
+            tbody.remove();
+          }
         }
         return tableElement;
       },

--- a/packages/editor/src/plugins/toolbar-plugin.tsx
+++ b/packages/editor/src/plugins/toolbar-plugin.tsx
@@ -327,6 +327,8 @@ export function ToolbarPlugin({
     (rows: number, columns: number) => {
       editor.dispatchCommand(INSERT_TABLE_COMMAND, {
         columns: String(columns),
+        // Match Portable Text display: first row is header, not first column
+        includeHeaders: { columns: false, rows: true },
         rows: String(rows),
       });
     },

--- a/packages/editor/src/rich-text-editor.tsx
+++ b/packages/editor/src/rich-text-editor.tsx
@@ -12,9 +12,14 @@ import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
+import { proseContent } from "@ykzts/ui/lib/prose";
 import type { EditorState, LexicalEditor } from "lexical";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ImageNode } from "./nodes/image-node";
+import {
+  $createProseTableNode,
+  ProseTableNode,
+} from "./nodes/prose-table-node";
 import { CodeExitPlugin } from "./plugins/code-exit-plugin";
 import { CodeHighlightPlugin } from "./plugins/code-highlight-plugin";
 import { EditorStatePlugin } from "./plugins/editor-state-plugin";
@@ -27,7 +32,8 @@ import {
   lexicalToPortableText,
 } from "./portable-text-serializer";
 
-// Minimal theme - @tailwindcss/typography handles most styling
+// Minimal theme — visual styling comes from @tailwindcss/typography (proseContent).
+// Only Lexical runtime needs (syntax tokens, nested-list marker fix) live here.
 const editorTheme = {
   code: "block overflow-x-auto whitespace-pre font-mono text-sm not-prose bg-muted/20 border border-border rounded p-4 my-2",
   codeHighlight: {
@@ -61,6 +67,12 @@ const editorTheme = {
     tag: "text-red-600 dark:text-red-400",
     url: "text-blue-600 dark:text-blue-400",
     variable: "text-orange-600 dark:text-orange-400",
+  },
+  // Nested list items wrap a nested list; hide the outer marker (Lexical requirement)
+  list: {
+    nested: {
+      listitem: "list-none",
+    },
   },
 };
 
@@ -106,7 +118,13 @@ export function RichTextEditor({
       ListItemNode,
       HeadingNode,
       QuoteNode,
-      TableNode,
+      // table > tbody > tr for @tailwindcss/typography
+      ProseTableNode,
+      {
+        replace: TableNode,
+        with: () => $createProseTableNode(),
+        withKlass: ProseTableNode,
+      },
       TableCellNode,
       TableRowNode,
     ],
@@ -149,7 +167,9 @@ export function RichTextEditor({
             <RichTextPlugin
               contentEditable={
                 <ContentEditable
-                  className="prose prose-theme prose-sm min-h-37.5 max-w-none overflow-auto px-4 py-3 text-foreground outline-none"
+                  className={proseContent(
+                    "min-h-37.5 max-w-none overflow-auto px-4 py-3 outline-none"
+                  )}
                   id={id}
                 />
               }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
     "./components/sonner": "./src/components/sonner.tsx",
     "./components/table": "./src/components/table.tsx",
     "./components/textarea": "./src/components/textarea.tsx",
+    "./lib/prose": "./src/lib/prose.ts",
     "./lib/utils": "./src/lib/utils.ts",
     "./styles/theme.css": "./src/styles/theme.css"
   },

--- a/packages/ui/src/lib/prose.ts
+++ b/packages/ui/src/lib/prose.ts
@@ -1,0 +1,17 @@
+import type { ClassValue } from "clsx";
+import { cn } from "./utils";
+
+/**
+ * Shared `@tailwindcss/typography` class names for Portable Text / rich text.
+ * Keep editor preview and published content on the same scale and link/paragraph styles.
+ */
+export const proseContentClassName =
+  "prose prose-theme prose-p:leading-relaxed prose-a:no-underline prose-a:hover:underline" as const;
+
+/**
+ * Compose prose content styles with layout / context classes via `cn` (tailwind-merge).
+ * Prefer this over string concatenation so conflicting utilities resolve predictably.
+ */
+export function proseContent(...inputs: ClassValue[]) {
+  return cn(proseContentClassName, ...inputs);
+}

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -179,6 +179,18 @@
   --tw-prose-td-borders: var(--color-border);
 }
 
+/*
+ * Lexical table cells always wrap content in <p>. Default prose paragraph
+ * margins break cell layout; keep cell text flush like published plain cells.
+ */
+.prose :where(td, th) :where(p) {
+  margin: 0;
+}
+
+.prose :where(td, th) :where(p + p) {
+  margin-top: 0.5em;
+}
+
 @utility shiki {
   @apply rounded-lg overflow-y-auto p-2 text-sm;
 }


### PR DESCRIPTION
## Summary

管理画面などのリッチテキストエディタ表示が、公開側の `@tailwindcss/typography`（`prose`）とずれていた問題を直します。

- 共有の `proseContent()`（`@ykzts/ui/lib/prose`）で blog / memo / portfolio / editor の prose クラスを統一
- Lexical テーブルを `thead`（全 th 行）+ `tbody` にルーティングし、公開 Portable Text と同じ DOM 構造に
- テーブル挿入は「1 行目ヘッダ」のみ（表示側と同じ）
- セル内の `<p>` は入力用に残し、prose の段落マージンは CSS で抑制

## Related issues

<!-- none -->

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [ ] `chore` / `ci` / `perf` / `style` — maintenance or tooling
- [ ] Breaking change

## How to test

1. `pnpm --filter @ykzts/editor test` が通ること（`ProseTableNode` の thead/tbody 分割を含む）
2. 管理画面 `http://localhost:3100/posts/new` でリッチテキストを開き、見出し・段落・リンクが公開記事と同程度の prose スケールであること
3. テーブルを挿入し、1 行目が `thead` / 以降が `tbody` になり、セル入力が可能で余白が詰まっていないこと
4. 既存記事の編集・保存後、公開側 blog のテーブル表示が従来どおりであること

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Changes are focused on a single concern
- [x] `pnpm check` passes (or will pass in CI)
- [x] Tests added/updated when behavior changes (`pnpm test`)
- [ ] Docs updated when user-facing behavior or setup changes
- [x] No secrets or credentials in the diff
- [ ] Supabase migrations tested locally when schema changes (`npx supabase db reset --local` or equivalent)

## Notes for reviewers

- Lexical の reconciler 都合で、編集中の行 DOM は slot 経由で thead/tbody に振り分けています（`table.removeChild` のパッチ含む）。中間行挿入などエッジケースは要確認です。
- 公開 HTML の永続化は Portable Text 経由のままです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リッチテキストエディターで、見出し行を含むテーブルを正しく編集・表示・保存できるようになりました。
  - テーブルのヘッダー行と本文行が、表示時に適切に区別されます。

- **改善**
  - ブログ、メモ、ポートフォリオなどのリッチテキスト表示で、共通のタイポグラフィスタイルを適用しました。
  - ネストされたリストやテーブル内の段落表示を調整し、レイアウトの一貫性を向上しました。

- **テスト**
  - テーブル構造とヘッダー・本文のDOM出力に関する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->