### PR TITLE
fix: group baserow docker images in renovate preset

### DIFF
--- a/renovate-config/README.md
+++ b/renovate-config/README.md
@@ -47,7 +47,7 @@ None - this is a configuration-only package
 - **Immediate PRs**: Creates pull requests without delay
 
 ### Specialized Groupings
-- **Docker Containers**: Groups container updates by project (Immich, Mastodon)
+- **Docker Containers**: Groups container updates by project (Baserow, Immich, Mastodon)
 - **Terraform Providers**: Groups Google Cloud provider updates
 - **Build Tools**: Special handling for development and build dependencies
 

--- a/renovate-config/default.json5
+++ b/renovate-config/default.json5
@@ -34,6 +34,12 @@
   minimumReleaseAge: '3 days',
   packageRules: [
     {
+      groupName: 'baserow docker containers',
+      groupSlug: 'baserow',
+      matchDatasources: ['docker'],
+      matchPackageNames: ['baserow/**']
+    },
+    {
       groupName: 'immich docker containers',
       groupSlug: 'immich',
       matchDatasources: ['docker'],


### PR DESCRIPTION
## Summary

stzky-infra で `baserow/backend` と `baserow/web-frontend` が別 PR になっていたため、共有 Renovate preset に Immich / Mastodon と同様の Docker グループルールを追加した。`baserow/**` を同一 PR にまとめる。

## Related issues

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [ ] `chore` / `ci` / `perf` / `style` — maintenance or tooling
- [ ] Breaking change

## How to test

1. `pnpm --filter @ykzts/renovate-config validate` が成功すること
2. マージ後、stzky-infra 上の Renovate が `baserow` グループ PR（例: `update baserow docker containers`）を作ること

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Changes are focused on a single concern
- [x] `pnpm check` passes (or will pass in CI)
- [x] Tests added/updated when behavior changes (`pnpm test`)
- [x] Docs updated when user-facing behavior or setup changes
- [x] No secrets or credentials in the diff
- [x] Supabase migrations tested locally when schema changes (`npx supabase db reset --local` or equivalent)

## Notes for reviewers

stzky-infra の compose を確認したところ、同一製品・共有バージョンで未グループだったのは baserow のみ。Immich は既に `ghcr.io/immich-app/**` でグループ済み。Grafana / Prometheus / Firecrawl はコンポーネントごとに独立したバージョンのためグループ対象外。
