### PR TITLE
fix(blog): resolve instant-nav URL data on post and archive routes

### DIFF
--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
@@ -9,13 +9,16 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@ykzts/ui/components/breadcrumb";
+import { Skeleton } from "@ykzts/ui/components/skeleton";
 import { getPostUrl } from "@ykzts/utils/blog-urls";
 import { isPortableTextValue } from "@ykzts/utils/portable-text";
 import type { Metadata, Route } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import ArticleContent from "@/components/article-content";
 import PostNavigation from "@/components/post-navigation";
 import SimilarPosts from "@/components/similar-posts";
+import SimilarPostsSkeleton from "@/components/similar-posts-skeleton";
 import TableOfContents from "@/components/table-of-contents";
 import { DEFAULT_POST_TITLE } from "@/lib/constants";
 import { extractHeadings } from "@/lib/extract-headings";
@@ -34,6 +37,18 @@ interface PageProps {
     slug: string;
   }>;
 }
+
+type ResolvedPost = NonNullable<Awaited<ReturnType<typeof getPostBySlug>>> & {
+  content: NonNullable<
+    NonNullable<Awaited<ReturnType<typeof getPostBySlug>>>["content"]
+  >;
+  profile: {
+    fediverse_creator?: string | null;
+    id: string;
+    name: string;
+  };
+  published_at: string;
+};
 
 export async function generateStaticParams() {
   const posts = await getAllPosts();
@@ -64,6 +79,8 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
+  "use cache";
+
   const { year, month, day, slug } = await params;
   const post = await getPostBySlug(slug);
 
@@ -138,7 +155,9 @@ export async function generateMetadata({
   };
 }
 
-export default async function PostDetailPage({ params }: PageProps) {
+async function resolvePublishedPost(
+  params: PageProps["params"]
+): Promise<{ post: ResolvedPost; year: string }> {
   const { year, month, day, slug } = await params;
   const post = await getPostBySlug(slug);
 
@@ -146,7 +165,6 @@ export default async function PostDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  // Validate URL date components match the post's published_at date
   if (post.published_at) {
     const publishedDate = new Date(post.published_at);
     const expectedYear = String(publishedDate.getUTCFullYear());
@@ -164,30 +182,58 @@ export default async function PostDetailPage({ params }: PageProps) {
       notFound();
     }
   } else {
-    // Draft posts with no published_at cannot be accessed via date-based URL
     notFound();
   }
 
-  // Validate content is valid PortableText
   if (!(post.content && isPortableTextValue(post.content))) {
     notFound();
   }
 
-  // Profile is required for author information
   if (!post.profile?.name) {
     notFound();
   }
 
-  // Fetch publisher profile and adjacent posts concurrently.
-  // getProfile() failure is tolerated; fall back to post.profile.name for publisher.
-  const [publisherProfile, { previousPost, nextPost }] = await Promise.all([
-    getProfile().catch(() => null),
-    getAdjacentPosts(slug),
-  ]);
+  return {
+    post: post as ResolvedPost,
+    year,
+  };
+}
 
-  const historyUrl = `${getPostUrl(post)}/history` as Route;
+async function PostBreadcrumb({ params }: PageProps) {
+  const { post, year } = await resolvePublishedPost(params);
 
-  // JSON-LD structured data for Article schema
+  return (
+    <Breadcrumb className="mb-6">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/blog" />}>ブログ</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href={`/blog/${year}`} />}>
+            {year}年
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{post.title}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function PostBreadcrumbFallback() {
+  return (
+    <div aria-hidden="true" className="mb-6">
+      <Skeleton className="h-4 w-56" />
+    </div>
+  );
+}
+
+async function PostJsonLd({ params }: PageProps) {
+  const { post } = await resolvePublishedPost(params);
+  const publisherProfile = await getProfile().catch(() => null);
   const baseUrl = getSiteOrigin().origin;
   const publisherName = publisherProfile?.name ?? post.profile.name;
   const jsonLd = {
@@ -208,99 +254,87 @@ export default async function PostDetailPage({ params }: PageProps) {
     },
   };
 
-  // Extract headings for Table of Contents
+  return (
+    <script
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data is safe with JSON.stringify
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      type="application/ld+json"
+    />
+  );
+}
+
+async function PostArticle({ params }: PageProps) {
+  const { post } = await resolvePublishedPost(params);
+  const historyUrl = `${getPostUrl(post)}/history` as Route;
   const headings = extractHeadings(post.content);
   const hasHeadings = headings.length > 0;
 
+  if (hasHeadings) {
+    return (
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_16rem]">
+        <ArticleContent
+          authorName={post.profile.name}
+          className="min-w-0"
+          content={post.content}
+          headings={headings}
+          historyUrl={historyUrl}
+          publishedAt={post.published_at}
+          tags={post.tags}
+          title={post.title}
+          versionDate={post.version_date}
+        />
+        <div className="hidden lg:block">
+          <TableOfContents headings={headings} variant="desktop" />
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <>
-      <script
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data is safe with JSON.stringify
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        type="application/ld+json"
-      />
-      <main className="px-6 py-8 md:px-12 lg:px-24">
-        <div className="mx-auto max-w-4xl">
-          <Breadcrumb className="mb-6">
-            <BreadcrumbList>
-              <BreadcrumbItem>
-                <BreadcrumbLink render={<Link href="/blog" />}>
-                  ブログ
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbLink render={<Link href={`/blog/${year}`} />}>
-                  {year}年
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-              <BreadcrumbItem>
-                <BreadcrumbPage>{post.title}</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-        </div>
-
-        {/* Grid layout: article body + ToC */}
-        <div className="mx-auto max-w-4xl">
-          {hasHeadings ? (
-            <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_16rem]">
-              {/* Main content */}
-              <ArticleContent
-                authorName={post.profile.name}
-                className="min-w-0"
-                content={post.content}
-                headings={headings}
-                historyUrl={historyUrl}
-                publishedAt={post.published_at}
-                tags={post.tags}
-                title={post.title}
-                versionDate={post.version_date}
-              />
-
-              {/* Desktop ToC sidebar */}
-              <div className="hidden lg:block">
-                <TableOfContents headings={headings} variant="desktop" />
-              </div>
-            </div>
-          ) : (
-            <ArticleContent
-              authorName={post.profile.name}
-              className="mx-auto max-w-3xl"
-              content={post.content}
-              headings={headings}
-              historyUrl={historyUrl}
-              publishedAt={post.published_at}
-              tags={post.tags}
-              title={post.title}
-              versionDate={post.version_date}
-            />
-          )}
-        </div>
-
-        {/* Full width: article navigation */}
-        <div className="mx-auto max-w-4xl">
-          <PostNavigation nextPost={nextPost} previousPost={previousPost} />
-        </div>
-
-        {/* Full width: related articles */}
-        <div className="mx-auto max-w-4xl">
-          <div aria-atomic="false" aria-live="polite">
-            <SimilarPostsSection postId={post.id} />
-          </div>
-        </div>
-      </main>
-    </>
+    <ArticleContent
+      authorName={post.profile.name}
+      className="mx-auto max-w-3xl"
+      content={post.content}
+      headings={headings}
+      historyUrl={historyUrl}
+      publishedAt={post.published_at}
+      tags={post.tags}
+      title={post.title}
+      versionDate={post.version_date}
+    />
   );
+}
+
+function PostArticleFallback() {
+  return (
+    <div aria-hidden="true" className="space-y-6">
+      <Skeleton className="h-10 w-3/4" />
+      <Skeleton className="h-4 w-1/3" />
+      <div className="space-y-3 pt-4">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+    </div>
+  );
+}
+
+async function PostAdjacentNav({ params }: PageProps) {
+  const { post } = await resolvePublishedPost(params);
+  const { previousPost, nextPost } = await getAdjacentPosts(post.slug);
+
+  return <PostNavigation nextPost={nextPost} previousPost={previousPost} />;
 }
 
 const SIMILAR_POSTS_LIMIT = 3;
 const SIMILAR_POSTS_THRESHOLD = 0.5;
 
-async function SimilarPostsSection({ postId }: { postId: string }) {
+async function SimilarPostsSection({ params }: PageProps) {
+  const { post } = await resolvePublishedPost(params);
   const result = await getSimilarPosts(
-    postId,
+    post.id,
     SIMILAR_POSTS_LIMIT,
     SIMILAR_POSTS_THRESHOLD
   ).then(
@@ -314,4 +348,41 @@ async function SimilarPostsSection({ postId }: { postId: string }) {
   }
 
   return <SimilarPosts posts={result.posts} />;
+}
+
+export default function PostDetailPage({ params }: PageProps) {
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PostJsonLd params={params} />
+      </Suspense>
+      <main className="px-6 py-8 md:px-12 lg:px-24">
+        <div className="mx-auto max-w-4xl">
+          <Suspense fallback={<PostBreadcrumbFallback />}>
+            <PostBreadcrumb params={params} />
+          </Suspense>
+        </div>
+
+        <div className="mx-auto max-w-4xl">
+          <Suspense fallback={<PostArticleFallback />}>
+            <PostArticle params={params} />
+          </Suspense>
+        </div>
+
+        <div className="mx-auto max-w-4xl">
+          <Suspense fallback={null}>
+            <PostAdjacentNav params={params} />
+          </Suspense>
+        </div>
+
+        <div className="mx-auto max-w-4xl">
+          <div aria-atomic="false" aria-live="polite">
+            <Suspense fallback={<SimilarPostsSkeleton />}>
+              <SimilarPostsSection params={params} />
+            </Suspense>
+          </div>
+        </div>
+      </main>
+    </>
+  );
 }

--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
@@ -232,8 +232,10 @@ function PostBreadcrumbFallback() {
 }
 
 async function PostJsonLd({ params }: PageProps) {
-  const { post } = await resolvePublishedPost(params);
-  const publisherProfile = await getProfile().catch(() => null);
+  const [{ post }, publisherProfile] = await Promise.all([
+    resolvePublishedPost(params),
+    getProfile().catch(() => null),
+  ]);
   const baseUrl = getSiteOrigin().origin;
   const publisherName = publisherProfile?.name ?? post.profile.name;
   const jsonLd = {

--- a/apps/blog/app/blog/[year]/page.tsx
+++ b/apps/blog/app/blog/[year]/page.tsx
@@ -8,10 +8,12 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@ykzts/ui/components/breadcrumb";
+import { Skeleton } from "@ykzts/ui/components/skeleton";
 import type { PortableTextValue } from "@ykzts/utils/portable-text";
 import { Rss } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import PostCard from "@/components/post-card";
 import YearNavigation from "@/components/year-navigation";
 import {
@@ -20,6 +22,7 @@ import {
   getPostCountByYear,
   getPostsByYear,
 } from "@/lib/supabase/posts";
+import { PostsSkeleton } from "../_components/posts";
 
 const YEAR_REGEX = /^\d{4}$/;
 
@@ -66,6 +69,8 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
+  "use cache";
+
   const { year: yearStr } = await params;
 
   if (yearStr === "_placeholder") {
@@ -101,29 +106,86 @@ export async function generateMetadata({
   };
 }
 
-export default async function YearArchivePage({ params }: PageProps) {
+async function resolveYear(params: PageProps["params"]) {
   const { year: yearStr } = await params;
 
-  if (yearStr === "_placeholder") {
+  if (yearStr === "_placeholder" || !YEAR_REGEX.test(yearStr)) {
     notFound();
   }
 
-  if (!YEAR_REGEX.test(yearStr)) {
-    notFound();
-  }
+  return Number.parseInt(yearStr, 10);
+}
 
-  const year = Number.parseInt(yearStr, 10);
+async function YearBreadcrumb({ params }: PageProps) {
+  const year = await resolveYear(params);
 
-  const posts = (await getPostsByYear(year)) as Post[];
+  return (
+    <Breadcrumb className="mb-4">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/blog" />}>ブログ</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{year}年</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function YearBreadcrumbFallback() {
+  return (
+    <div aria-hidden="true" className="mb-4">
+      <Skeleton className="h-4 w-32" />
+    </div>
+  );
+}
+
+async function YearHeading({ params }: PageProps) {
+  const year = await resolveYear(params);
   const count = await getPostCountByYear(year);
 
-  if (count === 0 || posts.length === 0) {
+  if (count === 0) {
     notFound();
   }
 
-  const { previousYear, nextYear } = await getAdjacentYears(year);
+  return (
+    <div className="mb-8 flex items-baseline justify-between">
+      <h1 className="font-bold text-3xl">
+        {year}年 ({count}件)
+      </h1>
+      <a
+        aria-label="ブログのAtomフィードを購読"
+        className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+        href="/blog.atom"
+        rel="alternate"
+        type="application/atom+xml"
+      >
+        <Rss className="h-4 w-4" />
+        <span>Atom</span>
+      </a>
+    </div>
+  );
+}
 
-  // Group posts by month (newest month first, within year newest first)
+function YearHeadingFallback() {
+  return (
+    <div
+      aria-hidden="true"
+      className="mb-8 flex items-baseline justify-between"
+    >
+      <Skeleton className="h-9 w-40" />
+      <Skeleton className="h-4 w-16" />
+    </div>
+  );
+}
+
+function groupPostsByMonth(posts: Post[]): {
+  availableMonths: number[];
+  monthGroups: MonthGroup[];
+  monthMap: Map<number, Post[]>;
+} {
   const monthMap = new Map<number, Post[]>();
   for (const post of posts) {
     if (!post.published_at) {
@@ -140,7 +202,7 @@ export default async function YearArchivePage({ params }: PageProps) {
   }
 
   const monthGroups: MonthGroup[] = Array.from(monthMap.entries())
-    .sort((a, b) => b[0] - a[0]) // desc month
+    .sort((a, b) => b[0] - a[0])
     .map(([month, monthPosts]) => ({
       month,
       posts: monthPosts,
@@ -148,88 +210,97 @@ export default async function YearArchivePage({ params }: PageProps) {
 
   const availableMonths = Array.from(monthMap.keys()).sort((a, b) => b - a);
 
+  return { availableMonths, monthGroups, monthMap };
+}
+
+async function YearMonthNav({ params }: PageProps) {
+  const year = await resolveYear(params);
+  const posts = (await getPostsByYear(year)) as Post[];
+  const { availableMonths, monthMap } = groupPostsByMonth(posts);
+
+  if (availableMonths.length <= 1) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="月別ナビゲーション" className="mb-8 border-b pb-4 text-sm">
+      <span className="mr-2 text-muted-foreground">月:</span>
+      {availableMonths.map((month, index) => {
+        const monthCount = monthMap.get(month)?.length ?? 0;
+        const anchor = `month-${String(month).padStart(2, "0")}`;
+        return (
+          <span key={month}>
+            {index > 0 && <span className="mx-1 text-muted-foreground">/</span>}
+            <a
+              className="underline-offset-4 hover:text-foreground hover:underline"
+              href={`#${anchor}`}
+            >
+              {month}月 ({monthCount})
+            </a>
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+async function YearPosts({ params }: PageProps) {
+  const year = await resolveYear(params);
+  const posts = (await getPostsByYear(year)) as Post[];
+
+  if (posts.length === 0) {
+    notFound();
+  }
+
+  const { monthGroups } = groupPostsByMonth(posts);
+
+  return (
+    <div className="space-y-12">
+      {monthGroups.map((group) => {
+        const anchor = `month-${String(group.month).padStart(2, "0")}`;
+        return (
+          <section className="group scroll-mt-16" id={anchor} key={group.month}>
+            <h2 className="mb-6 font-bold text-2xl group-target:-ml-2 group-target:rounded group-target:border-primary group-target:border-l-4 group-target:bg-muted/60 group-target:pr-2 group-target:pl-3 group-target:font-semibold group-target:transition-colors">
+              {group.month}月 ({group.posts.length}件)
+            </h2>
+            <div className="space-y-6">
+              {group.posts.map((post) => (
+                <PostCard key={post.id} post={post} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+async function YearNav({ params }: PageProps) {
+  const year = await resolveYear(params);
+  const { previousYear, nextYear } = await getAdjacentYears(year);
+
+  return <YearNavigation nextYear={nextYear} previousYear={previousYear} />;
+}
+
+export default function YearArchivePage({ params }: PageProps) {
   return (
     <main className="px-6 py-8 md:px-12 lg:px-24">
       <div className="mx-auto max-w-4xl">
-        <Breadcrumb className="mb-4">
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link href="/blog" />}>
-                ブログ
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{year}年</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-
-        <div className="mb-8 flex items-baseline justify-between">
-          <h1 className="font-bold text-3xl">
-            {year}年 ({count}件)
-          </h1>
-          <a
-            aria-label="ブログのAtomフィードを購読"
-            className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
-            href="/blog.atom"
-            rel="alternate"
-            type="application/atom+xml"
-          >
-            <Rss className="h-4 w-4" />
-            <span>Atom</span>
-          </a>
-        </div>
-
-        {availableMonths.length > 1 && (
-          <nav
-            aria-label="月別ナビゲーション"
-            className="mb-8 border-b pb-4 text-sm"
-          >
-            <span className="mr-2 text-muted-foreground">月:</span>
-            {availableMonths.map((month, index) => {
-              const monthCount = monthMap.get(month)?.length ?? 0;
-              const anchor = `month-${String(month).padStart(2, "0")}`;
-              return (
-                <span key={month}>
-                  {index > 0 && (
-                    <span className="mx-1 text-muted-foreground">/</span>
-                  )}
-                  <a
-                    className="underline-offset-4 hover:text-foreground hover:underline"
-                    href={`#${anchor}`}
-                  >
-                    {month}月 ({monthCount})
-                  </a>
-                </span>
-              );
-            })}
-          </nav>
-        )}
-
-        <div className="space-y-12">
-          {monthGroups.map((group) => {
-            const anchor = `month-${String(group.month).padStart(2, "0")}`;
-            return (
-              <section
-                className="group scroll-mt-16"
-                id={anchor}
-                key={group.month}
-              >
-                <h2 className="mb-6 font-bold text-2xl group-target:-ml-2 group-target:rounded group-target:border-primary group-target:border-l-4 group-target:bg-muted/60 group-target:pr-2 group-target:pl-3 group-target:font-semibold group-target:transition-colors">
-                  {group.month}月 ({group.posts.length}件)
-                </h2>
-                <div className="space-y-6">
-                  {group.posts.map((post) => (
-                    <PostCard key={post.id} post={post} />
-                  ))}
-                </div>
-              </section>
-            );
-          })}
-        </div>
-
-        <YearNavigation nextYear={nextYear} previousYear={previousYear} />
+        <Suspense fallback={<YearBreadcrumbFallback />}>
+          <YearBreadcrumb params={params} />
+        </Suspense>
+        <Suspense fallback={<YearHeadingFallback />}>
+          <YearHeading params={params} />
+        </Suspense>
+        <Suspense fallback={null}>
+          <YearMonthNav params={params} />
+        </Suspense>
+        <Suspense fallback={<PostsSkeleton count={6} />}>
+          <YearPosts params={params} />
+        </Suspense>
+        <Suspense fallback={null}>
+          <YearNav params={params} />
+        </Suspense>
       </div>
     </main>
   );

--- a/apps/blog/app/blog/tags/[tag]/layout.tsx
+++ b/apps/blog/app/blog/tags/[tag]/layout.tsx
@@ -9,6 +9,8 @@ interface TagLayoutProps {
 export async function generateMetadata({
   params,
 }: TagLayoutProps): Promise<Metadata> {
+  "use cache";
+
   const { tag } = await params;
   const decodedTag = decodeURIComponent(tag);
   const encodedTag = encodeURIComponent(decodedTag);
@@ -23,5 +25,5 @@ export async function generateMetadata({
 }
 
 export default function TagLayout({ children }: { children: ReactNode }) {
-  return <>{children}</>;
+  return children;
 }

--- a/apps/blog/app/blog/tags/[tag]/page.tsx
+++ b/apps/blog/app/blog/tags/[tag]/page.tsx
@@ -7,9 +7,11 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@ykzts/ui/components/breadcrumb";
+import { Skeleton } from "@ykzts/ui/components/skeleton";
 import { Rss } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import BlogPagination from "@/components/blog-pagination";
 import PostCard from "@/components/post-card";
 import {
@@ -18,6 +20,7 @@ import {
   getPostsByTag,
   POSTS_PER_PAGE,
 } from "@/lib/supabase/posts";
+import { PostsSkeleton } from "../../_components/posts";
 
 interface PageProps {
   params: Promise<{ tag: string }>;
@@ -39,6 +42,8 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
+  "use cache";
+
   const { tag } = await params;
   const decodedTag = decodeURIComponent(tag);
 
@@ -48,67 +53,129 @@ export async function generateMetadata({
   };
 }
 
-export default async function TagArchivePage({ params }: PageProps) {
+async function resolveTag(params: PageProps["params"]) {
   const { tag } = await params;
-  const decodedTag = decodeURIComponent(tag);
+  return decodeURIComponent(tag);
+}
 
-  const [posts, postCount] = await Promise.all([
-    getPostsByTag(decodedTag, 1),
-    getPostCountByTag(decodedTag),
-  ]);
+async function TagBreadcrumb({ params }: PageProps) {
+  const decodedTag = await resolveTag(params);
+
+  return (
+    <Breadcrumb className="mb-4">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<Link href="/blog" />}>ブログ</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{decodedTag}タグ</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function TagBreadcrumbFallback() {
+  return (
+    <div aria-hidden="true" className="mb-4">
+      <Skeleton className="h-4 w-40" />
+    </div>
+  );
+}
+
+async function TagHeading({ params }: PageProps) {
+  const decodedTag = await resolveTag(params);
+  const postCount = await getPostCountByTag(decodedTag);
+
+  if (postCount === 0) {
+    notFound();
+  }
+
+  return (
+    <div className="mb-8 flex items-baseline justify-between">
+      <h1 className="font-bold text-3xl">
+        {decodedTag} ({postCount}件)
+      </h1>
+      <a
+        aria-label={`${decodedTag}タグのAtomフィードを購読`}
+        className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+        href={`/blog/tags/${encodeURIComponent(decodedTag)}.atom`}
+        rel="alternate"
+        type="application/atom+xml"
+      >
+        <Rss className="h-4 w-4" />
+        <span>Atom</span>
+      </a>
+    </div>
+  );
+}
+
+function TagHeadingFallback() {
+  return (
+    <div
+      aria-hidden="true"
+      className="mb-8 flex items-baseline justify-between"
+    >
+      <Skeleton className="h-9 w-48" />
+      <Skeleton className="h-4 w-16" />
+    </div>
+  );
+}
+
+async function TagPosts({ params }: PageProps) {
+  const decodedTag = await resolveTag(params);
+  const posts = await getPostsByTag(decodedTag, 1);
 
   if (!posts || posts.length === 0) {
     notFound();
   }
 
+  return (
+    <div className="space-y-6">
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </div>
+  );
+}
+
+async function TagPaginationSection({ params }: PageProps) {
+  const decodedTag = await resolveTag(params);
+  const postCount = await getPostCountByTag(decodedTag);
   const totalPages = Math.ceil(postCount / POSTS_PER_PAGE);
 
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8">
+      <BlogPagination
+        baseUrl={`/blog/tags/${encodeURIComponent(decodedTag)}/page`}
+        currentPage={1}
+        totalPages={totalPages}
+      />
+    </div>
+  );
+}
+
+export default function TagArchivePage({ params }: PageProps) {
   return (
     <main className="px-6 py-8 md:px-12 lg:px-24">
       <div className="mx-auto max-w-4xl">
-        <Breadcrumb className="mb-4">
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link href="/blog" />}>
-                ブログ
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{decodedTag}タグ</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-
-        <div className="mb-8 flex items-baseline justify-between">
-          <h1 className="font-bold text-3xl">
-            {decodedTag} ({postCount}件)
-          </h1>
-          <a
-            aria-label={`${decodedTag}タグのAtomフィードを購読`}
-            className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
-            href={`/blog/tags/${encodeURIComponent(decodedTag)}.atom`}
-            rel="alternate"
-            type="application/atom+xml"
-          >
-            <Rss className="h-4 w-4" />
-            <span>Atom</span>
-          </a>
-        </div>
-        <div className="space-y-6">
-          {posts.map((post) => (
-            <PostCard key={post.id} post={post} />
-          ))}
-        </div>
-        {totalPages > 1 && (
-          <div className="mt-8">
-            <BlogPagination
-              baseUrl={`/blog/tags/${encodeURIComponent(decodedTag)}/page`}
-              currentPage={1}
-              totalPages={totalPages}
-            />
-          </div>
-        )}
+        <Suspense fallback={<TagBreadcrumbFallback />}>
+          <TagBreadcrumb params={params} />
+        </Suspense>
+        <Suspense fallback={<TagHeadingFallback />}>
+          <TagHeading params={params} />
+        </Suspense>
+        <Suspense fallback={<PostsSkeleton />}>
+          <TagPosts params={params} />
+        </Suspense>
+        <Suspense fallback={null}>
+          <TagPaginationSection params={params} />
+        </Suspense>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Next.js Cache Components / Instant Navigation 有効時、ブログの動的ルートで `params` を Suspense 外で await していたため、`instant-shell-url-data` 警告が出ていました。

個別記事・年別アーカイブ・タグ一覧を、静的シェル＋領域ごとの Suspense 境界に分割し、params 依存の `generateMetadata` には `"use cache"` を付与して修正しました。ページ全体を1枚の Suspense で包むのではなく、breadcrumb / heading / 記事一覧 / 本文などを分けています。

## Related issues

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [ ] `chore` / `ci` / `perf` / `style` — maintenance or tooling
- [ ] Breaking change

## How to test

1. `pnpm --filter @ykzts/blog dev` で blog を起動する
2. 次の URL を開き、dev overlay に `URL data` / `params outside of Suspense` が出ないことを確認する
   - `/blog/2025`（年別）
   - `/blog/tags/<tag>`（タグ）
   - `/blog/<year>/<month>/<day>/<slug>`（個別記事）
3. 各ページの見た目・ナビゲーションが従来どおりであることも確認する

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Changes are focused on a single concern
- [x] `pnpm check` passes (or will pass in CI)
- [ ] Tests added/updated when behavior changes (`pnpm test`)
- [ ] Docs updated when user-facing behavior or setup changes
- [x] No secrets or credentials in the diff
- [ ] Supabase migrations tested locally when schema changes (`npx supabase db reset --local` or equivalent)

## Notes for reviewers

- Pagination の hydration mismatch（shadcn `PaginationLink` / Base UI）は上流・見た目上は壊れていないため今回は未対応です
- `/blog/page/[num]` など、まだ同様の `params` 警告が残るルートがある可能性があります


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ブログ記事、年別アーカイブ、タグ別アーカイブの各ページで、パンくず・本文・投稿一覧・ナビゲーションを段階的に表示できるようになりました。
  - 読み込み中は各エリアにスケルトン表示が現れ、ページ全体の表示を待たずに閲覧を開始できます。
  - 年別アーカイブで月別ナビゲーションを利用できるようになりました。

- **バグ修正**
  - 無効な日付、年、タグや投稿が存在しない場合に、適切に見つからないページを表示するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->