### PR TITLE
style(blog): use full width without ToC and narrow sidebar

### DIFF
--- a/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
+++ b/apps/blog/app/blog/[year]/[month]/[day]/[slug]/page.tsx
@@ -273,7 +273,7 @@ async function PostArticle({ params }: PageProps) {
 
   if (hasHeadings) {
     return (
-      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_16rem]">
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_12rem]">
         <ArticleContent
           authorName={post.profile.name}
           className="min-w-0"
@@ -295,7 +295,6 @@ async function PostArticle({ params }: PageProps) {
   return (
     <ArticleContent
       authorName={post.profile.name}
-      className="mx-auto max-w-3xl"
       content={post.content}
       headings={headings}
       historyUrl={historyUrl}

--- a/apps/blog/app/blog/draft/[slug]/page.tsx
+++ b/apps/blog/app/blog/draft/[slug]/page.tsx
@@ -123,10 +123,10 @@ async function DraftPostContent({ params }: PageProps) {
 
       <div className="mx-auto max-w-4xl">
         {hasHeadings ? (
-          <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_16rem]">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_12rem]">
             <ArticleContent
               authorName={post.profile.name}
-              className="mx-auto min-w-0 max-w-3xl lg:mx-0 lg:max-w-none"
+              className="min-w-0"
               content={post.content}
               headings={headings}
               publishedAt={post.published_at}
@@ -141,7 +141,6 @@ async function DraftPostContent({ params }: PageProps) {
         ) : (
           <ArticleContent
             authorName={post.profile.name}
-            className="mx-auto max-w-3xl"
             content={post.content}
             headings={headings}
             publishedAt={post.published_at}


### PR DESCRIPTION
## Summary

ブログ個別記事で目次がない場合、`max-w-3xl` により本文が狭く中央寄せされ、左右がすかすかに見えていました。この制約を外し、親コンテナ（`max-w-4xl`）幅いっぱいに表示するようにしました。あわせてデスクトップ目次の幅を 16rem から 12rem に狭め、本文側のスペースを増やしています。公開記事と下書きプレビューの両方に同じレイアウトを適用しています。

## Related issues

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [x] `chore` / `ci` / `perf` / `style` — maintenance or tooling
- [ ] Breaking change

## How to test

1. 目次のないブログ記事を開き、本文が `max-w-4xl` コンテナ幅いっぱいに広がっていることを確認する
2. 見出しのある記事をデスクトップ幅で開き、目次サイドバーが以前より狭い（12rem）ことと、本文レイアウトが崩れないことを確認する
3. 下書きプレビュー（`/blog/draft/[slug]`）でも同様のレイアウトになっていることを確認する

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Changes are focused on a single concern
- [x] `pnpm check` passes (or will pass in CI)
- [ ] Tests added/updated when behavior changes (`pnpm test`)
- [ ] Docs updated when user-facing behavior or setup changes
- [x] No secrets or credentials in the diff
- [ ] Supabase migrations tested locally when schema changes (`npx supabase db reset --local` or equivalent)

## Notes for reviewers

- 変更は Tailwind のクラス調整のみ（`page.tsx` 2 ファイル）
- 目次幅は `16rem` → `12rem`。さらに調整が必要なら CSS の grid 定義だけ変えればよいです

